### PR TITLE
feat: display external links from RolloutTest annotations

### DIFF
--- a/frontend/dev-mock-api.ts
+++ b/frontend/dev-mock-api.ts
@@ -1,0 +1,315 @@
+/**
+ * Vite dev server plugin that mocks the backend API for visual testing.
+ *
+ * Usage: In vite.config.ts, import and add to the plugins array:
+ *
+ *   import { mockApiPlugin } from './dev-mock-api';
+ *   // ...
+ *   plugins: [mockApiPlugin(), mkcert(), ...]
+ *
+ * Then run `npm run dev` and navigate to:
+ *   https://localhost:5173/rollouts/default/hello-world
+ *
+ * Remove the plugin from vite.config.ts when done testing.
+ */
+
+import type { Plugin } from 'vite';
+
+const NAMESPACE = 'default';
+const ROLLOUT_NAME = 'hello-world';
+const APP_NAMESPACE = 'hello-world';
+const KUSTOMIZATION_NAME = 'hello-world';
+const KUSTOMIZATION_NAMESPACE = 'default';
+
+const mockRolloutResponse = {
+	rollout: {
+		apiVersion: 'kuberik.com/v1alpha1',
+		kind: 'Rollout',
+		metadata: {
+			name: ROLLOUT_NAME,
+			namespace: NAMESPACE,
+			annotations: {
+				'dashboard.rollout.kuberik.com/description':
+					'Example application for testing rollout features.'
+			},
+			labels: {
+				environment: 'dev'
+			}
+		},
+		spec: {
+			releasesImagePolicy: `${NAMESPACE}/${ROLLOUT_NAME}`,
+			healthCheckSelector: { matchLabels: { app: ROLLOUT_NAME } },
+			versionHistoryLimit: 10,
+			minBakeTime: '1s'
+		},
+		status: {
+			wantedVersion: 'f68d0ac',
+			currentVersion: 'f68d0ac',
+			previousVersion: 'a1b2c3d',
+			history: [
+				{
+					version: { tag: 'f68d0ac', version: 'f68d0ac' },
+					timestamp: new Date(Date.now() - 16 * 60 * 1000).toISOString(),
+					message: '*Automatic deployment*',
+					triggeredBy: { kind: 'System', name: 'System' },
+					bakeStatus: 'Succeeded',
+					bakeStartTime: new Date(Date.now() - 6 * 60 * 1000).toISOString(),
+					bakeEndTime: new Date(Date.now() - 5 * 60 * 1000).toISOString()
+				},
+				{
+					version: { tag: 'a1b2c3d', version: 'a1b2c3d' },
+					timestamp: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+					message: '*Automatic deployment*',
+					triggeredBy: { kind: 'System', name: 'System' },
+					bakeStatus: 'Succeeded',
+					bakeStartTime: new Date(Date.now() - 115 * 60 * 1000).toISOString(),
+					bakeEndTime: new Date(Date.now() - 114 * 60 * 1000).toISOString()
+				},
+				{
+					version: { tag: 'e4f5a6b', version: 'e4f5a6b' },
+					timestamp: new Date(Date.now() - 5 * 60 * 60 * 1000).toISOString(),
+					message: 'Fix database connection pooling',
+					triggeredBy: { kind: 'User', name: 'alice' },
+					bakeStatus: 'Failed',
+					bakeStatusMessage: 'Health check failed: readiness probe timeout',
+					bakeStartTime: new Date(Date.now() - 295 * 60 * 1000).toISOString(),
+					bakeEndTime: new Date(Date.now() - 290 * 60 * 1000).toISOString()
+				},
+				{
+					version: { tag: '7c8d9e0', version: '7c8d9e0' },
+					timestamp: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+					message: '*Automatic deployment*',
+					triggeredBy: { kind: 'System', name: 'System' },
+					bakeStatus: 'Succeeded',
+					bakeStartTime: new Date(Date.now() - 23.9 * 60 * 60 * 1000).toISOString(),
+					bakeEndTime: new Date(Date.now() - 23.8 * 60 * 60 * 1000).toISOString()
+				},
+				{
+					version: { tag: 'b3c4d5e', version: 'b3c4d5e' },
+					timestamp: new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString(),
+					message: 'Initial release',
+					triggeredBy: { kind: 'User', name: 'bob' },
+					bakeStatus: 'Succeeded',
+					bakeStartTime: new Date(Date.now() - 47.9 * 60 * 60 * 1000).toISOString(),
+					bakeEndTime: new Date(Date.now() - 47.8 * 60 * 60 * 1000).toISOString()
+				}
+			]
+		}
+	},
+	kustomizations: {
+		items: [
+			{
+				apiVersion: 'kustomize.toolkit.fluxcd.io/v1',
+				kind: 'Kustomization',
+				metadata: {
+					name: KUSTOMIZATION_NAME,
+					namespace: KUSTOMIZATION_NAMESPACE
+				},
+				spec: {},
+				status: { conditions: [] }
+			}
+		]
+	},
+	ociRepositories: { items: [] },
+	rolloutGates: { items: [] },
+	environment: {
+		apiVersion: 'kuberik.com/v1alpha1',
+		kind: 'Environment',
+		metadata: { name: 'dev', namespace: NAMESPACE },
+		spec: { label: 'dev' }
+	},
+	kruiseRollout: null,
+	rolloutTests: { items: [] }
+};
+
+const mockManagedResources = {
+	managedResources: [
+		{
+			groupVersionKind: 'apps/v1/Deployment',
+			name: ROLLOUT_NAME,
+			namespace: APP_NAMESPACE,
+			status: 'Current',
+			message: '',
+			lastModified: new Date().toISOString(),
+			object: {
+				apiVersion: 'apps/v1',
+				kind: 'Deployment',
+				metadata: { name: ROLLOUT_NAME, namespace: APP_NAMESPACE },
+				spec: { replicas: 1 },
+				status: { readyReplicas: 1, replicas: 1 }
+			}
+		},
+		// -- KruiseRollout so the deployment timeline renders --
+		{
+			groupVersionKind: 'rollouts.kruise.io/v1beta1/Rollout',
+			name: ROLLOUT_NAME,
+			namespace: APP_NAMESPACE,
+			status: 'Current',
+			message: '',
+			lastModified: new Date().toISOString(),
+			object: {
+				apiVersion: 'rollouts.kruise.io/v1beta1',
+				kind: 'Rollout',
+				metadata: { name: ROLLOUT_NAME, namespace: APP_NAMESPACE },
+				spec: {
+					workloadRef: { apiVersion: 'apps/v1', kind: 'Deployment', name: ROLLOUT_NAME },
+					strategy: {
+						canary: {
+							steps: [
+								{ replicas: 1, pause: { duration: 5 } },
+								{ replicas: '100%' },
+								{ replicas: '100%' }
+							]
+						}
+					}
+				},
+				status: {
+					phase: 'Healthy',
+					canaryStatus: {
+						currentStepIndex: 2,
+						currentStepState: 'Completed',
+						canaryRevision: 'f68d0ac',
+						observedWorkloadGeneration: 1
+					},
+					conditions: [{ type: 'Progressing', status: 'True', reason: 'Completed' }]
+				}
+			}
+		},
+		// -- RolloutTest WITH link annotations (this is what we're testing!) --
+		{
+			groupVersionKind: 'rollout.kuberik.com/v1alpha1/RolloutTest',
+			name: `${ROLLOUT_NAME}-test`,
+			namespace: APP_NAMESPACE,
+			status: 'Current',
+			message: '',
+			lastModified: new Date().toISOString(),
+			object: {
+				apiVersion: 'rollout.kuberik.com/v1alpha1',
+				kind: 'RolloutTest',
+				metadata: {
+					name: `${ROLLOUT_NAME}-test`,
+					namespace: APP_NAMESPACE,
+					annotations: {
+						'rollout.kuberik.com/link.Logs':
+							'https://example.com/logs?service=hello-world&live=true',
+						'rollout.kuberik.com/link.CI':
+							'https://example.com/ci/test/runs?service=hello-world&version=f68d0ac'
+					}
+				},
+				spec: {
+					rolloutName: ROLLOUT_NAME,
+					stepIndex: 2,
+					jobTemplate: {
+						template: {
+							spec: {
+								containers: [
+									{
+										name: 'test',
+										env: [
+											{ name: 'DD_SERVICE', value: ROLLOUT_NAME },
+											{ name: 'DD_ENV', value: 'dev' },
+											{ name: 'DD_VERSION', value: 'f68d0ac' }
+										]
+									}
+								]
+							}
+						}
+					}
+				},
+				status: {
+					phase: 'Succeeded',
+					retryCount: 0,
+					activePods: 0,
+					succeededPods: 1,
+					failedPods: 0,
+					jobName: `${ROLLOUT_NAME}-test-f68d0ac`
+				}
+			}
+		}
+	]
+};
+
+const mockPermissions = {
+	permissions: { update: true, patch: true },
+	resource: {
+		apiGroup: 'kuberik.com',
+		kind: 'Rollout',
+		name: ROLLOUT_NAME,
+		namespace: NAMESPACE
+	}
+};
+
+const mockHealthChecks = {
+	healthChecks: [
+		{
+			name: ROLLOUT_NAME,
+			namespace: APP_NAMESPACE,
+			kind: 'Deployment',
+			apiVersion: 'apps/v1',
+			status: 'Healthy',
+			message: 'Deployment is available'
+		}
+	]
+};
+
+export function mockApiPlugin(): Plugin {
+	return {
+		name: 'mock-api',
+		configureServer(server) {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			server.middlewares.use((req: any, res: any, next: () => void) => {
+				if (!req.url?.startsWith('/api/')) return next();
+
+				res.setHeader('Content-Type', 'application/json');
+
+				// GET /api/rollouts
+				if (req.url === '/api/rollouts') {
+					return res.end(
+						JSON.stringify({
+							items: [mockRolloutResponse.rollout]
+						})
+					);
+				}
+
+				// GET /api/rollouts/:namespace/:name
+				if (req.url === `/api/rollouts/${NAMESPACE}/${ROLLOUT_NAME}`) {
+					return res.end(JSON.stringify(mockRolloutResponse));
+				}
+
+				// GET /api/rollouts/:namespace/:name/permissions/all
+				if (req.url === `/api/rollouts/${NAMESPACE}/${ROLLOUT_NAME}/permissions/all`) {
+					return res.end(JSON.stringify(mockPermissions));
+				}
+
+				// GET /api/rollouts/:namespace/:name/rollout-tests
+				if (req.url === `/api/rollouts/${NAMESPACE}/${ROLLOUT_NAME}/rollout-tests`) {
+					const rolloutTestObject = mockManagedResources.managedResources.find(
+						(r) => r.groupVersionKind === 'rollout.kuberik.com/v1alpha1/RolloutTest'
+					);
+					return res.end(
+						JSON.stringify({
+							rolloutTests: { items: rolloutTestObject ? [rolloutTestObject.object] : [] },
+							kruiseRollout: null
+						})
+					);
+				}
+
+				// GET /api/rollouts/:namespace/:name/health-checks
+				if (req.url === `/api/rollouts/${NAMESPACE}/${ROLLOUT_NAME}/health-checks`) {
+					return res.end(JSON.stringify(mockHealthChecks));
+				}
+
+				// GET /api/kustomizations/:namespace/:name/managed-resources
+				if (
+					req.url ===
+					`/api/kustomizations/${KUSTOMIZATION_NAMESPACE}/${KUSTOMIZATION_NAME}/managed-resources`
+				) {
+					return res.end(JSON.stringify(mockManagedResources));
+				}
+
+				// Fallback: return empty JSON for any unhandled API routes
+				return res.end(JSON.stringify({}));
+			});
+		}
+	};
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
+		"dev:mock": "MOCK_API=1 vite dev",
 		"build": "vite build",
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync || echo ''",

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -319,3 +319,17 @@ export function extractURLFromGatewayOrIngress(resource: any, groupVersionKind: 
 
     return null;
 }
+
+const LINK_ANNOTATION_PREFIX = 'rollout.kuberik.com/link.';
+
+export function parseLinkAnnotations(
+	annotations: Record<string, string> | undefined
+): { label: string; url: string }[] {
+	if (!annotations) return [];
+	return Object.entries(annotations)
+		.filter(([key]) => key.startsWith(LINK_ANNOTATION_PREFIX))
+		.map(([key, url]) => ({
+			label: key.slice(LINK_ANNOTATION_PREFIX.length),
+			url
+		}));
+}

--- a/frontend/src/routes/rollouts/[namespace]/[name]/+page.svelte
+++ b/frontend/src/routes/rollouts/[namespace]/[name]/+page.svelte
@@ -85,7 +85,10 @@
 		hasUnblockFailedAnnotation,
 		getDisplayVersion,
 		extractURLFromGatewayOrIngress,
-		parseLinkAnnotations
+		parseLinkAnnotations,
+		extractDatadogInfoFromContainers,
+		buildDatadogTestRunsUrl,
+		buildDatadogLogsUrl
 	} from '$lib/utils';
 	import { now } from '$lib/stores/time';
 	import SourceViewer from '$lib/components/SourceViewer.svelte';
@@ -1838,6 +1841,7 @@
 																							{@const retryCount = test.status?.retryCount || 0}
 																							{#if test.metadata}
 																								{@const linkAnnotations = parseLinkAnnotations(test.metadata.annotations)}
+																								{@const ddInfo = extractDatadogInfoFromContainers(test.spec?.jobTemplate?.template?.spec?.containers || [])}
 																								<div class="flex items-center gap-2">
 																									<Tooltip
 																										class="z-50"
@@ -1899,7 +1903,7 @@
 																											{test.status.activePods} active
 																										</span>
 																									{/if}
-																									{#if linkAnnotations.length > 0 || phase === 'Failed'}
+																									{#if linkAnnotations.length > 0 || ddInfo || phase === 'Failed'}
 																										<div class="ml-auto flex items-center gap-3">
 																											{#if phase === 'Failed'}
 																												<a
@@ -1920,6 +1924,26 @@
 																													<ArrowUpRightFromSquareOutline class="h-3 w-3" />
 																												</a>
 																											{/each}
+																											{#if ddInfo}
+																												<a
+																													href={buildDatadogLogsUrl(ddInfo.service, ddInfo.env)}
+																													target="_blank"
+																													rel="noopener noreferrer"
+																													class="inline-flex items-center gap-1 text-xs font-medium text-purple-600 hover:text-purple-800 hover:underline dark:text-purple-400 dark:hover:text-purple-300"
+																												>
+																													<DatadogLogo class="h-3 w-3" />
+																													Logs
+																												</a>
+																												<a
+																													href={buildDatadogTestRunsUrl(ddInfo.service, getDisplayVersion(latestEntry.version))}
+																													target="_blank"
+																													rel="noopener noreferrer"
+																													class="inline-flex items-center gap-1 text-xs font-medium text-purple-600 hover:text-purple-800 hover:underline dark:text-purple-400 dark:hover:text-purple-300"
+																												>
+																													<DatadogLogo class="h-3 w-3" />
+																													CI
+																												</a>
+																											{/if}
 																										</div>
 																									{/if}
 																								</div>

--- a/frontend/src/routes/rollouts/[namespace]/[name]/+page.svelte
+++ b/frontend/src/routes/rollouts/[namespace]/[name]/+page.svelte
@@ -84,7 +84,8 @@
 		hasFailedBakeStatus,
 		hasUnblockFailedAnnotation,
 		getDisplayVersion,
-		extractURLFromGatewayOrIngress
+		extractURLFromGatewayOrIngress,
+		parseLinkAnnotations
 	} from '$lib/utils';
 	import { now } from '$lib/stores/time';
 	import SourceViewer from '$lib/components/SourceViewer.svelte';
@@ -1836,6 +1837,7 @@
 																							{@const phase = test.status?.phase || 'Unknown'}
 																							{@const retryCount = test.status?.retryCount || 0}
 																							{#if test.metadata}
+																								{@const linkAnnotations = parseLinkAnnotations(test.metadata.annotations)}
 																								<div class="flex items-center gap-2">
 																									<Tooltip
 																										class="z-50"
@@ -1897,13 +1899,28 @@
 																											{test.status.activePods} active
 																										</span>
 																									{/if}
-																									{#if phase === 'Failed'}
-																										<a
-																											href="/rollouts/{namespace}/{name}/logs?tab=tests"
-																											class="ml-auto text-xs font-medium text-blue-600 hover:text-blue-800 hover:underline dark:text-blue-400 dark:hover:text-blue-300"
-																										>
-																											View Logs
-																										</a>
+																									{#if linkAnnotations.length > 0 || phase === 'Failed'}
+																										<div class="ml-auto flex items-center gap-3">
+																											{#if phase === 'Failed'}
+																												<a
+																													href="/rollouts/{namespace}/{name}/logs?tab=tests"
+																													class="text-xs font-medium text-blue-600 hover:text-blue-800 hover:underline dark:text-blue-400 dark:hover:text-blue-300"
+																												>
+																													View Logs
+																												</a>
+																											{/if}
+																											{#each linkAnnotations as link}
+																												<a
+																													href={link.url}
+																													target="_blank"
+																													rel="noopener noreferrer"
+																													class="inline-flex items-center gap-1 text-xs font-medium text-blue-600 hover:text-blue-800 hover:underline dark:text-blue-400 dark:hover:text-blue-300"
+																												>
+																													{link.label}
+																													<ArrowUpRightFromSquareOutline class="h-3 w-3" />
+																												</a>
+																											{/each}
+																										</div>
 																									{/if}
 																								</div>
 																							{/if}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,9 +4,13 @@ import { svelteTesting } from '@testing-library/svelte/vite';
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 import mkcert from 'vite-plugin-mkcert';
+import { mockApiPlugin } from './dev-mock-api';
+
+const useMockApi = !!process.env.MOCK_API;
 
 export default defineConfig({
 	plugins: [
+		...(useMockApi ? [mockApiPlugin()] : []),
 		mkcert(),
 		tailwindcss(),
 		sveltekit(),
@@ -18,14 +22,15 @@ export default defineConfig({
 	server: {
 		https: true,
 		host: "0.0.0.0",
-		proxy: {
-			'/api': {
-				target: 'https://192.168.1.102.nip.io:8080', // The API is running locally via IIS on this port
-				changeOrigin: true,
-				secure: false,
-				// rewrite: (path) => path.replace(/^\/api/, '') // The local API has a slightly different path
+		...(!useMockApi && {
+			proxy: {
+				'/api': {
+					target: 'https://192.168.1.102.nip.io:8080',
+					changeOrigin: true,
+					secure: false,
+				}
 			}
-		},
+		}),
 		allowedHosts: true,
 	},
 	test: {


### PR DESCRIPTION
Read annotations matching `rollout.kuberik.com/link.<Label>` from RolloutTest metadata and render them as clickable links next to each test in the Rollout Tests section. This allows users to configure external links (e.g. logs, CI dashboards) directly on the RolloutTest resource.

Apart from that if integrates Datadog by default if `DD_ENV`, `DD_SERVICE` and `DD_VERSION` are present in the rollout test.

UI Example:
<img width="1534" height="918" alt="image" src="https://github.com/user-attachments/assets/42b3c8f6-9392-4baf-b353-f906e66a759e" />
<img width="1532" height="753" alt="image" src="https://github.com/user-attachments/assets/95f53c4b-bfec-4e66-9ea8-9b610e16da62" />

