### PR TITLE
fix: use DD_VERSION for CI links and resolve History page Datadog links

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,19 @@ jobs:
         with:
           version: 10
 
+      - name: Set version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+          else
+            echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          fi
+
       - name: Build frontend
         working-directory: frontend
+        env:
+          VITE_APP_VERSION: ${{ steps.version.outputs.version }}
         run: |
           pnpm install
           pnpm run build
@@ -60,15 +71,6 @@ jobs:
         run: |
           curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
           sudo mv kustomize /usr/local/bin/
-
-      - name: Set version
-        id: version
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
-          else
-            echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
-          fi
 
       - name: Log in to Container Registry
         uses: docker/login-action@v3

--- a/frontend/dev-mock-api.ts
+++ b/frontend/dev-mock-api.ts
@@ -208,7 +208,7 @@ const mockManagedResources = {
 										env: [
 											{ name: 'DD_SERVICE', value: ROLLOUT_NAME },
 											{ name: 'DD_ENV', value: 'dev' },
-											{ name: 'DD_VERSION', value: 'f68d0ac' }
+											{ name: 'DD_VERSION', value: 'main-1770831919-f68d0ac3ed1185943c9105df735a099a2165c7ce' }
 										]
 									}
 								]
@@ -266,7 +266,7 @@ export function mockApiPlugin(): Plugin {
 				if (req.url === '/api/rollouts') {
 					return res.end(
 						JSON.stringify({
-							items: [mockRolloutResponse.rollout]
+							rollouts: { items: [mockRolloutResponse.rollout] }
 						})
 					);
 				}

--- a/frontend/src/lib/Navbar.svelte
+++ b/frontend/src/lib/Navbar.svelte
@@ -307,6 +307,11 @@
 					</Popover>
 				{/if}
 			{/if}
+			{#if import.meta.env.VITE_APP_VERSION}
+				<span class="hidden text-xs text-gray-400 dark:text-gray-500 sm:inline">
+					{import.meta.env.VITE_APP_VERSION}
+				</span>
+			{/if}
 			<button
 				class="rounded-lg bg-gray-100 p-1.5 text-gray-800 transition-colors hover:bg-gray-200 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600 sm:p-2"
 				onclick={() => theme.toggle()}

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -271,6 +271,33 @@ describe('extractDatadogInfoFromContainers', () => {
         });
     });
 
+    it('should extract service, env and version when all are present', () => {
+        const containers = [{
+            env: [
+                { name: 'DD_SERVICE', value: 'my-service' },
+                { name: 'DD_ENV', value: 'production' },
+                { name: 'DD_VERSION', value: 'main-1770831919-d4cd2de3ed1185943c9105df735a099a2165c7ce' }
+            ]
+        }];
+        expect(extractDatadogInfoFromContainers(containers)).toEqual({
+            service: 'my-service',
+            env: 'production',
+            version: 'main-1770831919-d4cd2de3ed1185943c9105df735a099a2165c7ce'
+        });
+    });
+
+    it('should return info without version when DD_VERSION is absent', () => {
+        const containers = [{
+            env: [
+                { name: 'DD_SERVICE', value: 'my-service' },
+                { name: 'DD_ENV', value: 'staging' }
+            ]
+        }];
+        const result = extractDatadogInfoFromContainers(containers);
+        expect(result).toEqual({ service: 'my-service', env: 'staging' });
+        expect(result?.version).toBeUndefined();
+    });
+
     it('should find DD tags in a second container if first has none', () => {
         const containers = [
             { env: [{ name: 'FOO', value: 'bar' }] },

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -323,6 +323,7 @@ export function extractURLFromGatewayOrIngress(resource: any, groupVersionKind: 
 export interface DatadogInfo {
 	service: string;
 	env: string;
+	version?: string;
 }
 
 export function extractDatadogInfoFromContainers(
@@ -331,11 +332,13 @@ export function extractDatadogInfoFromContainers(
 	for (const container of containers) {
 		let ddService: string | null = null;
 		let ddEnv: string | null = null;
+		let ddVersion: string | null = null;
 		for (const envVar of container.env || []) {
 			if (envVar.name === 'DD_SERVICE' && envVar.value) ddService = envVar.value;
 			if (envVar.name === 'DD_ENV' && envVar.value) ddEnv = envVar.value;
+			if (envVar.name === 'DD_VERSION' && envVar.value) ddVersion = envVar.value;
 		}
-		if (ddService && ddEnv) return { service: ddService, env: ddEnv };
+		if (ddService && ddEnv) return { service: ddService, env: ddEnv, ...(ddVersion ? { version: ddVersion } : {}) };
 	}
 	return null;
 }

--- a/frontend/src/routes/rollouts/[namespace]/[name]/+page.svelte
+++ b/frontend/src/routes/rollouts/[namespace]/[name]/+page.svelte
@@ -1935,7 +1935,7 @@
 																													Logs
 																												</a>
 																												<a
-																													href={buildDatadogTestRunsUrl(ddInfo.service, getDisplayVersion(latestEntry.version))}
+																													href={buildDatadogTestRunsUrl(ddInfo.service, ddInfo.version || getDisplayVersion(latestEntry.version))}
 																													target="_blank"
 																													rel="noopener noreferrer"
 																													class="inline-flex items-center gap-1 text-xs font-medium text-purple-600 hover:text-purple-800 hover:underline dark:text-purple-400 dark:hover:text-purple-300"


### PR DESCRIPTION
The CI test runs link was using the short SHA tag from rollout history instead of the full version string from DD_VERSION. Extract DD_VERSION from RolloutTest containers and use it for accurate Datadog filtering.

Fix History page Datadog links not appearing by fetching RolloutTests through managed resources (same approach as Overview page), since the rollout-tests endpoint searches the wrong namespace.

Add dashboard version display in the navbar, injected at build time via VITE_APP_VERSION in the release workflow.

<img width="3068" height="1852" alt="image" src="https://github.com/user-attachments/assets/a6003afc-307f-4fc0-aa68-300b7cf07f8c" />
