### PR TITLE
feat(dashboard): AlertPanel + recovery-mode UI

### DIFF
--- a/frontend/src/lib/components/AlertPanel.svelte
+++ b/frontend/src/lib/components/AlertPanel.svelte
@@ -1,0 +1,155 @@
+<svelte:options runes={true} />
+
+<script lang="ts">
+	import type { Snippet, Component } from 'svelte';
+	import {
+		ExclamationCircleSolid,
+		InfoCircleSolid,
+		PauseSolid,
+		HeartSolid
+	} from 'flowbite-svelte-icons';
+
+	type Severity = 'error' | 'warning' | 'info' | 'pinned';
+
+	interface Props {
+		severity?: Severity;
+		title: string;
+		message?: string;
+		footnote?: string;
+		quoted?: boolean;
+		icon?: Component;
+		pulse?: boolean;
+		actions?: Snippet;
+		extra?: Snippet;
+	}
+
+	let {
+		severity = 'info',
+		title,
+		message,
+		footnote,
+		quoted = false,
+		icon,
+		pulse = false,
+		actions,
+		extra
+	}: Props = $props();
+
+	const palette = $derived.by(() => {
+		switch (severity) {
+			case 'error':
+				return {
+					container:
+						'bg-gradient-to-r from-red-100 via-red-50 to-red-100 shadow-2xl shadow-red-200/60 ring-1 ring-red-300/60 dark:from-red-950 dark:via-red-900 dark:to-red-950 dark:shadow-red-950/50 dark:ring-red-800/60',
+					glowA: 'bg-red-400/8 dark:bg-red-500/10',
+					glowB: 'bg-red-300/10 dark:bg-red-400/8',
+					ping: 'bg-red-500/30 dark:bg-red-500/40',
+					iconWrap:
+						'bg-red-200 ring-2 ring-red-400/60 dark:bg-red-500/20 dark:ring-red-500/50',
+					iconColor: 'text-red-600 dark:text-red-300',
+					title: 'text-red-900 dark:text-white',
+					message: 'text-red-700/75 dark:text-red-200/75',
+					footnote: 'text-red-700/60 dark:text-red-200/55',
+					quoteBorder: 'border-red-400/60 dark:border-red-500/40',
+					defaultIcon: ExclamationCircleSolid
+				};
+			case 'warning':
+				return {
+					container:
+						'bg-gradient-to-r from-amber-100 via-amber-50 to-amber-100 shadow-2xl shadow-amber-200/60 ring-1 ring-amber-300/60 dark:from-amber-950 dark:via-amber-900 dark:to-amber-950 dark:shadow-amber-950/50 dark:ring-amber-800/60',
+					glowA: 'bg-amber-400/8 dark:bg-amber-500/10',
+					glowB: 'bg-amber-300/10 dark:bg-amber-400/8',
+					ping: 'bg-amber-500/25 dark:bg-amber-500/30',
+					iconWrap:
+						'bg-amber-200 ring-2 ring-amber-400/60 dark:bg-amber-500/20 dark:ring-amber-500/50',
+					iconColor: 'text-amber-600 dark:text-amber-300',
+					title: 'text-amber-900 dark:text-white',
+					message: 'text-amber-700/80 dark:text-amber-200/75',
+					footnote: 'text-amber-700/60 dark:text-amber-200/55',
+					quoteBorder: 'border-amber-400/60 dark:border-amber-500/40',
+					defaultIcon: ExclamationCircleSolid
+				};
+			case 'pinned':
+				return {
+					container:
+						'bg-gradient-to-r from-orange-100 via-orange-50 to-orange-100 shadow-2xl shadow-orange-200/60 ring-1 ring-orange-300/60 dark:from-orange-950 dark:via-orange-900 dark:to-orange-950 dark:shadow-orange-950/50 dark:ring-orange-800/60',
+					glowA: 'bg-orange-400/8 dark:bg-orange-500/10',
+					glowB: 'bg-orange-300/10 dark:bg-orange-400/8',
+					ping: 'bg-orange-500/25 dark:bg-orange-500/30',
+					iconWrap:
+						'bg-orange-200 ring-2 ring-orange-400/60 dark:bg-orange-500/20 dark:ring-orange-500/50',
+					iconColor: 'text-orange-600 dark:text-orange-300',
+					title: 'text-orange-900 dark:text-white',
+					message: 'text-orange-700/80 dark:text-orange-200/75',
+					footnote: 'text-orange-700/60 dark:text-orange-200/55',
+					quoteBorder: 'border-orange-400/60 dark:border-orange-500/40',
+					defaultIcon: PauseSolid
+				};
+			case 'info':
+			default:
+				return {
+					container:
+						'bg-gradient-to-r from-blue-100 via-blue-50 to-blue-100 shadow-2xl shadow-blue-200/60 ring-1 ring-blue-300/60 dark:from-blue-950 dark:via-blue-900 dark:to-blue-950 dark:shadow-blue-950/50 dark:ring-blue-800/60',
+					glowA: 'bg-blue-400/8 dark:bg-blue-500/10',
+					glowB: 'bg-blue-300/10 dark:bg-blue-400/8',
+					ping: 'bg-blue-500/25 dark:bg-blue-500/30',
+					iconWrap:
+						'bg-blue-200 ring-2 ring-blue-400/60 dark:bg-blue-500/20 dark:ring-blue-500/50',
+					iconColor: 'text-blue-600 dark:text-blue-300',
+					title: 'text-blue-900 dark:text-white',
+					message: 'text-blue-700/80 dark:text-blue-200/75',
+					footnote: 'text-blue-700/60 dark:text-blue-200/55',
+					quoteBorder: 'border-blue-400/60 dark:border-blue-500/40',
+					defaultIcon: InfoCircleSolid
+				};
+		}
+	});
+
+	const Icon = $derived(icon ?? palette.defaultIcon);
+</script>
+
+<div class="mb-4">
+	<div class="relative overflow-hidden rounded-xl {palette.container}">
+		<div class="pointer-events-none absolute inset-0 overflow-hidden">
+			<div class="absolute -right-10 -top-10 h-48 w-48 rounded-full {palette.glowA} blur-3xl"></div>
+			<div class="absolute -bottom-6 left-1/4 h-32 w-32 rounded-full {palette.glowB} blur-2xl"></div>
+		</div>
+
+		<div class="relative flex flex-col gap-4 px-5 py-4 sm:flex-row sm:items-center sm:gap-x-8 sm:px-6 sm:py-5">
+			<div class="flex min-w-0 flex-1 items-center gap-4">
+				<div class="relative shrink-0">
+					{#if pulse}
+						<div class="absolute inset-0 animate-ping rounded-full {palette.ping}"></div>
+					{/if}
+					<div class="relative flex h-10 w-10 items-center justify-center rounded-full {palette.iconWrap}">
+						<Icon class="h-6 w-6 {palette.iconColor}" />
+					</div>
+				</div>
+				<div class="min-w-0">
+					<div class="flex flex-wrap items-center gap-2">
+						<p class="text-base font-bold tracking-tight {palette.title}">{title}</p>
+						{#if extra}{@render extra()}{/if}
+					</div>
+					{#if message}
+						{#if quoted}
+							<blockquote class="mt-1.5 border-l-2 pl-3 italic break-words text-sm {palette.message} {palette.quoteBorder}">
+								{message}
+							</blockquote>
+						{:else}
+							<p class="mt-0.5 break-words text-sm {palette.message}">{message}</p>
+						{/if}
+					{/if}
+					{#if footnote}
+						<p class="mt-1 break-words text-xs {palette.footnote}">{footnote}</p>
+					{/if}
+				</div>
+			</div>
+
+			{#if actions}
+				<div class="flex items-center gap-3 sm:shrink-0">
+					{@render actions()}
+				</div>
+			{/if}
+		</div>
+	</div>
+</div>

--- a/frontend/src/lib/components/FailurePanel.svelte
+++ b/frontend/src/lib/components/FailurePanel.svelte
@@ -108,6 +108,9 @@
 							An error occurred during deployment.
 						{/if}
 					</p>
+					<p class="mt-1 text-xs text-red-700/60 dark:text-red-200/55">
+						Automated deployments are paused until this is resolved.
+					</p>
 				</div>
 			</div>
 

--- a/frontend/src/lib/components/RecoveryModeWarningModal.svelte
+++ b/frontend/src/lib/components/RecoveryModeWarningModal.svelte
@@ -1,0 +1,88 @@
+<svelte:options runes={true} />
+
+<script lang="ts">
+	import { Modal, Button } from 'flowbite-svelte';
+	import { ExclamationCircleSolid } from 'flowbite-svelte-icons';
+
+	type Reason = 'previous-failed' | 'unhealthy-health-checks';
+
+	interface Props {
+		open: boolean;
+		reason: Reason;
+		versionDisplay?: string | null;
+		onContinue: () => void;
+		onCancel?: () => void;
+	}
+
+	let {
+		open = $bindable(),
+		reason,
+		versionDisplay = null,
+		onContinue,
+		onCancel = () => {}
+	}: Props = $props();
+
+	const title = $derived(
+		reason === 'previous-failed' ? 'Recovery deploy' : 'Deploy during incident'
+	);
+
+	const summary = $derived.by(() => {
+		if (reason === 'previous-failed') {
+			return 'The previous deployment failed. Continuing will start a new deployment in recovery mode.';
+		}
+		return 'Health checks are currently unhealthy. Continuing will force-deploy into an active incident in recovery mode.';
+	});
+</script>
+
+<Modal bind:open size="md" autoclose={false}>
+	<div class="space-y-4">
+		<div class="flex items-start gap-3">
+			<div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-amber-100 ring-2 ring-amber-300/60 dark:bg-amber-500/20 dark:ring-amber-500/50">
+				<ExclamationCircleSolid class="h-6 w-6 text-amber-600 dark:text-amber-300" />
+			</div>
+			<div class="min-w-0">
+				<h3 class="text-lg font-semibold text-gray-900 dark:text-white">{title}</h3>
+				{#if versionDisplay}
+					<p class="text-sm text-gray-500 dark:text-gray-400">Version {versionDisplay}</p>
+				{/if}
+			</div>
+		</div>
+
+		<p class="text-sm text-gray-700 dark:text-gray-300">{summary}</p>
+
+		<div class="rounded-lg border border-amber-300/60 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-700/60 dark:bg-amber-950/40 dark:text-amber-200">
+			<p class="font-medium">In recovery mode:</p>
+			<ul class="mt-1.5 list-disc space-y-1 pl-5">
+				<li>Health check failures will <strong>not</strong> mark this deployment as failed.</li>
+				<li>The deployment will sit waiting for health checks to recover.</li>
+				{#if reason === 'unhealthy-health-checks'}
+					<li>Once health checks become healthy and bake starts, normal failure detection resumes.</li>
+				{:else}
+					<li>If the new deployment also fails to recover, the rollout will not transition to Failed.</li>
+				{/if}
+				<li>If the deployment is genuinely broken, watch logs and health checks closely.</li>
+			</ul>
+		</div>
+
+		<div class="flex justify-end gap-2">
+			<Button
+				color="light"
+				onclick={() => {
+					open = false;
+					onCancel();
+				}}
+			>
+				Cancel
+			</Button>
+			<Button
+				color="yellow"
+				onclick={() => {
+					open = false;
+					onContinue();
+				}}
+			>
+				I understand, continue
+			</Button>
+		</div>
+	</div>
+</Modal>

--- a/frontend/src/lib/components/ScheduleStatus.svelte
+++ b/frontend/src/lib/components/ScheduleStatus.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Alert, Popover } from 'flowbite-svelte';
+	import { Popover } from 'flowbite-svelte';
 	import {
 		CalendarWeekSolid,
 		ClockSolid,
@@ -7,6 +7,7 @@
 		CloseOutline
 	} from 'flowbite-svelte-icons';
 	import type { Rollout } from '$lib/types';
+	import AlertPanel from './AlertPanel.svelte';
 
 	type RolloutSchedule = {
 		metadata: { name: string; namespace: string };
@@ -90,15 +91,80 @@
 		return earliestTransition ? earliestTransition.toISOString() : null;
 	});
 
-	let blockingSchedules = $derived(
-		allSchedules
-			.filter((s) => {
-				const { active } = s.status;
-				const { action } = s.spec;
-				return (action === 'Allow' && !active) || (action === 'Deny' && active);
-			})
-			.map((s) => s.metadata.name)
+	let blockingSchedulesFull = $derived(
+		allSchedules.filter((s) => {
+			const { active } = s.status;
+			const { action } = s.spec;
+			return (action === 'Allow' && !active) || (action === 'Deny' && active);
+		})
 	);
+
+	let blockingSchedules = $derived(blockingSchedulesFull.map((s) => s.metadata.name));
+
+	const DAY_ORDER: Record<string, number> = {
+		Monday: 0,
+		Tuesday: 1,
+		Wednesday: 2,
+		Thursday: 3,
+		Friday: 4,
+		Saturday: 5,
+		Sunday: 6,
+		Mon: 0,
+		Tue: 1,
+		Wed: 2,
+		Thu: 3,
+		Fri: 4,
+		Sat: 5,
+		Sun: 6
+	};
+	const DAY_SHORT = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
+	function formatDays(days: string[]): string {
+		const sorted = [...days]
+			.map((d) => (d in DAY_ORDER ? DAY_ORDER[d] : -1))
+			.filter((i) => i >= 0)
+			.sort((a, b) => a - b);
+		if (sorted.length === 0) return days.join(', ');
+		// Collapse consecutive runs into ranges (Mon-Fri).
+		const ranges: string[] = [];
+		let start = sorted[0];
+		let prev = sorted[0];
+		for (let i = 1; i <= sorted.length; i++) {
+			if (i === sorted.length || sorted[i] !== prev + 1) {
+				ranges.push(start === prev ? DAY_SHORT[start] : `${DAY_SHORT[start]}–${DAY_SHORT[prev]}`);
+				if (i < sorted.length) {
+					start = sorted[i];
+					prev = sorted[i];
+				}
+			} else {
+				prev = sorted[i];
+			}
+		}
+		return ranges.join(', ');
+	}
+
+	function formatRule(
+		rule: {
+			name?: string;
+			timeRange?: { start: string; end: string };
+			daysOfWeek?: string[];
+			dateRange?: { start: string; end: string };
+		},
+		timezone: string | undefined
+	): string {
+		const parts: string[] = [];
+		if (rule.daysOfWeek && rule.daysOfWeek.length > 0) {
+			parts.push(formatDays(rule.daysOfWeek));
+		}
+		if (rule.timeRange) {
+			parts.push(`${rule.timeRange.start}–${rule.timeRange.end}`);
+		}
+		if (rule.dateRange) {
+			parts.push(`${rule.dateRange.start} → ${rule.dateRange.end}`);
+		}
+		const body = parts.join(' · ') || rule.name || 'Always';
+		return timezone ? `${body} (${timezone})` : body;
+	}
 
 	let allowingSchedules = $derived(
 		allSchedules
@@ -211,70 +277,93 @@
 
 {#if !loading && !error && allSchedules.length > 0}
 	{#if isBlocked}
-		<!-- Blocked State - Yellow Alert -->
-		<Alert color="yellow" class="mb-4">
-			<div class="flex items-center justify-between">
-				<div class="flex items-center gap-3">
-					<ExclamationCircleSolid class="h-5 w-5" />
-					<div>
-						<div class="font-semibold">Deployments Currently Blocked</div>
-						<div class="mt-1 text-sm">
-							{#if nextChange}
-								Will be allowed in <span class="font-medium"
-									>{formatTimeUntil(nextChange)}</span
-								>
-								({formatTime(nextChange)})
-							{:else}
-								Check schedule rules for deployment windows
-							{/if}
-						</div>
-					</div>
-				</div>
+		<AlertPanel
+			severity="warning"
+			title="Deployments currently blocked"
+			message={nextChange
+				? `Will be allowed in ${formatTimeUntil(nextChange)} (${formatTime(nextChange)}).`
+				: 'Check schedule rules for deployment windows.'}
+			icon={CalendarWeekSolid}
+			pulse
+		>
+			{#snippet actions()}
+				<button
+					type="button"
+					id="schedule-details"
+					class="flex cursor-pointer items-center gap-1.5 rounded-lg bg-amber-800/10 px-3 py-1.5 text-xs font-medium text-amber-900 ring-1 ring-amber-400/30 transition hover:bg-amber-800/15 hover:ring-amber-400/50 dark:bg-white/10 dark:text-white/90 dark:ring-white/20 dark:hover:bg-white/15"
+				>
+					{blockingSchedules.length} schedule{blockingSchedules.length > 1 ? 's' : ''}
+				</button>
+			{/snippet}
+		</AlertPanel>
+		<Popover
+			triggeredBy="#schedule-details"
+			placement="bottom-end"
+			arrow={false}
+			defaultClass=""
+			class="z-20 w-96 max-w-[90vw] rounded-xl border border-amber-300/70 bg-gradient-to-br from-amber-50 via-white to-amber-50 p-0 text-amber-950 shadow-2xl shadow-amber-300/30 dark:border-amber-700/60 dark:from-amber-950 dark:via-amber-900/80 dark:to-amber-950 dark:text-amber-50 dark:shadow-amber-950/50"
+		>
+			<div class="border-b border-amber-200/70 px-4 py-3 dark:border-amber-800/60">
 				<div class="flex items-center gap-2">
-					<CalendarWeekSolid class="h-4 w-4" />
-					<button
-						type="button"
-						id="schedule-details"
-						class="text-sm underline hover:no-underline"
-					>
-						{blockingSchedules.length} schedule{blockingSchedules.length > 1 ? 's' : ''}
-					</button>
+					<CalendarWeekSolid class="h-4 w-4 text-amber-600 dark:text-amber-300" />
+					<p class="text-sm font-semibold tracking-tight">
+						{blockingSchedulesFull.length === 1 ? 'Blocking schedule' : 'Blocking schedules'}
+					</p>
 				</div>
 			</div>
-		</Alert>
-		<Popover triggeredBy="#schedule-details" class="w-80 text-sm" placement="bottom">
-			<div class="space-y-2 p-3">
-				<div class="font-semibold text-gray-900 dark:text-white">Blocking Schedules:</div>
-				<ul class="list-inside list-disc space-y-1 text-gray-700 dark:text-gray-300">
-					{#each blockingSchedules as name}
-						<li>{name}</li>
-					{/each}
-				</ul>
-			</div>
+			<ul class="divide-y divide-amber-200/60 dark:divide-amber-800/40">
+				{#each blockingSchedulesFull as schedule}
+					<li class="px-4 py-3">
+						<div class="mb-2 flex items-center justify-between gap-2">
+							<span class="truncate text-sm font-medium text-amber-900 dark:text-amber-100">
+								{schedule.metadata.name}
+							</span>
+							<span
+								class="shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ring-1 {schedule
+									.spec.action === 'Deny'
+									? 'bg-red-100 text-red-700 ring-red-300/60 dark:bg-red-500/20 dark:text-red-200 dark:ring-red-700/50'
+									: 'bg-emerald-100 text-emerald-700 ring-emerald-300/60 dark:bg-emerald-500/20 dark:text-emerald-200 dark:ring-emerald-700/50'}"
+							>
+								{schedule.spec.action}
+							</span>
+						</div>
+						{#if schedule.spec.rules?.length}
+							<ul class="space-y-1">
+								{#each schedule.spec.rules as rule}
+									<li class="flex items-start gap-2 text-xs text-amber-800/90 dark:text-amber-200/85">
+										<ClockSolid class="mt-0.5 h-3 w-3 shrink-0 text-amber-500/80 dark:text-amber-400/80" />
+										<span class="break-words">{formatRule(rule, schedule.spec.timezone)}</span>
+									</li>
+								{/each}
+							</ul>
+						{/if}
+						{#if schedule.status?.nextTransition}
+							<p class="mt-2 text-xs text-amber-700/80 dark:text-amber-300/70">
+								Allowed in <span class="font-medium">{formatTimeUntil(schedule.status.nextTransition)}</span>
+								· {formatTime(schedule.status.nextTransition)}
+							</p>
+						{/if}
+					</li>
+				{/each}
+			</ul>
 		</Popover>
 	{:else if isAllowed && isClosingSoon && !isWarningDismissed}
-		<!-- Warning: Window closing soon - Dismissable -->
-		<Alert color="yellow" class="mb-4">
-			<div class="flex items-center justify-between">
-				<div class="flex items-center gap-3">
-					<ClockSolid class="h-5 w-5" />
-					<div>
-						<div class="font-semibold">Deployment Window Closing Soon</div>
-						<div class="mt-1 text-sm">
-							Window closes in <span class="font-medium">{formatTimeUntil(nextChange!)}</span>
-							({formatTime(nextChange!)})
-						</div>
-					</div>
-				</div>
+		<AlertPanel
+			severity="warning"
+			title="Deployment window closing soon"
+			message={`Window closes in ${formatTimeUntil(nextChange!)} (${formatTime(nextChange!)}).`}
+			icon={ClockSolid}
+		>
+			{#snippet actions()}
 				<button
 					type="button"
 					onclick={dismissWarning}
-					class="ml-auto inline-flex items-center rounded-lg p-1.5 text-yellow-500 hover:bg-yellow-200 dark:text-yellow-400 dark:hover:bg-gray-700"
+					class="inline-flex items-center rounded-lg p-1.5 text-amber-700 transition hover:bg-amber-200/60 dark:text-amber-300 dark:hover:bg-amber-800/40"
 					aria-label="Dismiss"
 				>
 					<CloseOutline class="h-5 w-5" />
 				</button>
-			</div>
-		</Alert>
+			{/snippet}
+		</AlertPanel>
 	{/if}
 {/if}

--- a/frontend/src/routes/rollouts/[namespace]/[name]/+page.svelte
+++ b/frontend/src/routes/rollouts/[namespace]/[name]/+page.svelte
@@ -1348,7 +1348,12 @@
 				{/if}
 
 				<!-- ══ BAKE FAILURE DISABLED (RECOVERY MODE) ══ -->
-				{#if bakeFailureDisabledCondition}
+				<!--
+					The condition is set when a deploy starts and persists until the next
+					deploy starts; only show the banner while the active deploy is still
+					running (Deploying or InProgress).
+				-->
+				{#if bakeFailureDisabledCondition && (latestEntry.bakeStatus === 'Deploying' || latestEntry.bakeStatus === 'InProgress')}
 					<AlertPanel
 						severity="info"
 						title="Recovery mode"

--- a/frontend/src/routes/rollouts/[namespace]/[name]/+page.svelte
+++ b/frontend/src/routes/rollouts/[namespace]/[name]/+page.svelte
@@ -93,6 +93,8 @@
 	import GitHubViewButton from '$lib/components/GitHubViewButton.svelte';
 	import DeployModal from '$lib/components/DeployModal.svelte';
 	import FailurePanel from '$lib/components/FailurePanel.svelte';
+	import AlertPanel from '$lib/components/AlertPanel.svelte';
+	import RecoveryModeWarningModal from '$lib/components/RecoveryModeWarningModal.svelte';
 	import DeploymentPipelineCard from '$lib/components/DeploymentPipelineCard.svelte';
 	import StatusSpinner from '$lib/components/StatusSpinner.svelte';
 	import ResourceCard from '$lib/components/ResourceCard.svelte';
@@ -168,6 +170,13 @@
 				return false;
 			});
 	});
+
+	const deploymentBlockedCondition = $derived(
+		rollout?.status?.conditions?.find((c) => c.type === 'DeploymentBlocked' && c.status === 'True')
+	);
+	const bakeFailureDisabledCondition = $derived(
+		rollout?.status?.conditions?.find((c) => c.type === 'BakeFailureDisabled' && c.status === 'True')
+	);
 
 	// Get the first stalled kruise rollout for retry functionality
 	const stalledKruiseRollout = $derived.by(() => {
@@ -265,6 +274,36 @@
 	let pinVersionToggle = $state(false);
 	let deployExplanation = $state('');
 	let deployConfirmationVersion = $state('');
+
+	// Recovery-mode pre-confirmation modal state
+	let showRecoveryWarningModal = $state(false);
+	let recoveryWarningReason = $state<'previous-failed' | 'unhealthy-health-checks'>(
+		'previous-failed'
+	);
+
+	function recoveryModeReason(): 'previous-failed' | 'unhealthy-health-checks' | null {
+		const currentBakeStatus = rollout?.status?.history?.[0]?.bakeStatus;
+		if (currentBakeStatus && currentBakeStatus !== 'Succeeded') {
+			return 'previous-failed';
+		}
+		if (healthChecks?.some((hc) => hc.status?.status === 'Unhealthy')) {
+			return 'unhealthy-health-checks';
+		}
+		return null;
+	}
+
+	// Intercept transitions to the deploy confirmation modal: if the action would put the
+	// rollout into recovery mode, show the warning modal first. The warning modal's
+	// onContinue then opens the actual DeployModal.
+	function requestDeployModal() {
+		const reason = recoveryModeReason();
+		if (reason) {
+			recoveryWarningReason = reason;
+			showRecoveryWarningModal = true;
+		} else {
+			showDeployModal = true;
+		}
+	}
 
 	// New variables for pin version mode
 	let isPinVersionMode = $state(false);
@@ -1189,7 +1228,6 @@
 		<div class="px-4 py-8 sm:px-5"><Alert color="yellow">Release not found</Alert></div>
 	{:else}
 		<div class="px-4 pt-4 pb-10 sm:px-5">
-			<ScheduleStatus {rollout} />
 			{#if rollout.status?.history?.[0]}
 				{@const latestEntry = rollout.status.history[0]}
 				{@const environment = rolloutQuery.data?.environment}
@@ -1279,6 +1317,9 @@
 					{/if}
 				</div>
 
+				<!-- ══ SCHEDULE STATUS (blocking / closing-soon) ══ -->
+				<ScheduleStatus {rollout} />
+
 				<!-- ══ FAILURE PANEL ══ -->
 				{#if isFailed}
 					<FailurePanel
@@ -1293,6 +1334,40 @@
 						onRetry={retryDeployment}
 						onSuccess={(m) => { toastType = 'success'; toastMessage = m; showToast = true; setTimeout(() => (showToast = false), 3000); }}
 						onError={(m) => { toastType = 'error'; toastMessage = m; showToast = true; setTimeout(() => (showToast = false), 3000); }}
+					/>
+				{/if}
+
+				<!-- ══ DEPLOYMENT BLOCKED ══ -->
+				{#if deploymentBlockedCondition && !isFailed && latestEntry.bakeStatus !== 'Deploying' && latestEntry.bakeStatus !== 'InProgress'}
+					<AlertPanel
+						severity="warning"
+						title="Deployment paused"
+						message={deploymentBlockedCondition.message || 'Health checks are unhealthy.'}
+						pulse
+					/>
+				{/if}
+
+				<!-- ══ BAKE FAILURE DISABLED (RECOVERY MODE) ══ -->
+				{#if bakeFailureDisabledCondition}
+					<AlertPanel
+						severity="info"
+						title="Recovery mode"
+						message={bakeFailureDisabledCondition.message ||
+							'Health check failures will not fail this deployment.'}
+					/>
+				{/if}
+
+				<!-- ══ PINNED VERSION ══ -->
+				{#if rollout.spec?.wantedVersion && !isPinnedVersionCustom}
+					{@const trig = latestEntry?.triggeredBy}
+					{@const author = trig?.kind === 'User' && trig?.name ? trig.name : null}
+					{@const pinnedBy = author ? `Pinned by ${author}` : 'Pinned'}
+					<AlertPanel
+						severity="pinned"
+						title="Version pinned"
+						message={latestEntry?.message}
+						quoted={!!latestEntry?.message}
+						footnote="{pinnedBy} · Automated deployments are paused until the pin is cleared."
 					/>
 				{/if}
 
@@ -1324,16 +1399,9 @@
 													{latestEntry.bakeStatus}
 												</span>
 											</div>
-											<!-- Metadata line: pinned, upgrades, custom, hash -->
-											{#if (rollout.spec?.wantedVersion && !isPinnedVersionCustom) || isCurrentVersionCustom || (rollout.status?.releaseCandidates?.length ?? 0) > 0 || (getRevisionInfo(latestEntry.version) && formatRevision(getRevisionInfo(latestEntry.version)!) !== getDisplayVersion(latestEntry.version))}
+											<!-- Metadata line: upgrades, custom, hash (pinned shown as alert above) -->
+											{#if isCurrentVersionCustom || (rollout.status?.releaseCandidates?.length ?? 0) > 0 || (getRevisionInfo(latestEntry.version) && formatRevision(getRevisionInfo(latestEntry.version)!) !== getDisplayVersion(latestEntry.version))}
 												<div class="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
-													{#if rollout.spec?.wantedVersion && !isPinnedVersionCustom}
-														<span
-															class="flex items-center gap-1 font-medium text-amber-600 dark:text-amber-400"
-														>
-															<PauseSolid class="h-3 w-3" /> Pinned{#if latestEntry.message}<span class="font-normal italic text-amber-600/80 dark:text-amber-400/70"> · {latestEntry.message}</span>{/if}
-														</span>
-													{/if}
 													{#if rollout.status?.releaseCandidates && rollout.status.releaseCandidates.length > 0}
 														<span
 															class="flex items-center gap-1 text-orange-600 dark:text-orange-400"
@@ -1444,7 +1512,7 @@
 														const currentVersionName = getDisplayVersion(currentVersion);
 														const targetVersionName = getDisplayVersion(previousVersion.version);
 														deployExplanation = `Rollback from ${currentVersionName} to ${targetVersionName} due to issues with the current deployment.`;
-														showDeployModal = true;
+														requestDeployModal();
 													}
 												}}
 											>
@@ -1690,7 +1758,7 @@
 															const mustPin = isOlderThanCurrent(version) || isCustom;
 															isPinVersionMode = mustPin;
 															pinVersionToggle = mustPin;
-															showDeployModal = true;
+															requestDeployModal();
 														}}
 													>
 														Deploy
@@ -1804,7 +1872,6 @@
 				type="text"
 				placeholder="Search versions..."
 				bind:value={searchQuery}
-				style="font-size: 16px"
 				class="w-full rounded-lg border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 placeholder-gray-400 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 focus:outline-none dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-500 dark:focus:border-blue-500"
 			/>
 		</div>
@@ -1973,8 +2040,8 @@
 				disabled={!selectedVersion}
 				onclick={() => {
 					if (!selectedVersion) return;
-					showDeployModal = true;
 					showPinModal = false;
+					requestDeployModal();
 				}}
 			>
 				Continue
@@ -2098,6 +2165,15 @@
 		toastMessage = m;
 		showToast = true;
 		setTimeout(() => (showToast = false), 3000);
+	}}
+/>
+
+<RecoveryModeWarningModal
+	bind:open={showRecoveryWarningModal}
+	reason={recoveryWarningReason}
+	versionDisplay={selectedVersionDisplay()}
+	onContinue={() => {
+		showDeployModal = true;
 	}}
 />
 


### PR DESCRIPTION
## Summary
- New `AlertPanel` component matching `FailurePanel`'s visual language (gradient/glow, severity-based palette). Reusable for warning/info/pinned/error. Supports a quoted-message variant and a small footnote line for attribution-style content.
- New `RecoveryModeWarningModal` shown before pin / force-deploy when the action would put the rollout into recovery mode (previous bake non-Succeeded OR any health check currently `Unhealthy`).
- `ScheduleStatus` migrated from flowbite Alert to `AlertPanel`. Blocking-schedule popover redesigned with formatted rule details (day ranges collapsed, time windows, timezone, Allow/Deny badges, next-transition).
- New `BakeFailureDisabled` and `DeploymentBlocked` banners on the rollout page. `DeploymentBlocked` is hidden while a deployment is running or already failed (FailurePanel + a new "Automated deployments are paused until this is resolved." sub-line cover those cases).
- Pinned indicator moved out of the inline status-card metadata into a dedicated `AlertPanel` showing the user's pin message as a quoted attribution with "Pinned by &lt;user&gt;" footnote.

## Why
Pairs with the controller PR ([rollout-controller#44](https://github.com/kuberik/rollout-controller/pull/44)) which adds the `BakeFailureDisabled` / `DeploymentBlocked` conditions and the recovery-mode flag. Users previously had no visible signal that a rollout couldn't fail (recovery mode), or that automatic deploys were paused on health checks — and could initiate a pin/force-deploy without realizing it would enter recovery mode.

## Test plan
- [x] `npx svelte-check`: no new errors (5 pre-existing).
- [x] Verified live on dev cluster (`hello-multi-dev`):
  - Force-deploy during incident shows the blue "Recovery mode" panel with the right reason.
  - `DeploymentBlocked` warning panel surfaces with health-check message; clears when health checks recover.
  - Pin alert renders with quoted message and "Pinned by &lt;user&gt;" footnote.
  - Schedule popover shows formatted rules + Allow/Deny badge.
  - FailurePanel sub-line confirms automated deploys are paused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)