### PR TITLE
feat(dashboard): add Datadog APM Trace link next to per-test Logs/CI buttons

### DIFF
--- a/frontend/src/lib/components/DeploymentPipelineCard.svelte
+++ b/frontend/src/lib/components/DeploymentPipelineCard.svelte
@@ -26,7 +26,8 @@
 		parseLinkAnnotations,
 		extractDatadogInfoFromContainers,
 		buildDatadogTestRunsUrl,
-		buildDatadogLogsUrl
+		buildDatadogLogsUrl,
+		buildDatadogTraceSearchUrl
 	} from '$lib/utils';
 	import { now } from '$lib/stores/time';
 	import type { Rollout, RolloutTest, HealthCheck, KruiseRollout } from '../../types';
@@ -755,6 +756,18 @@
 										class="inline-flex items-center gap-0.5 font-medium text-purple-600 hover:underline dark:text-purple-400"
 									>
 										<DatadogLogo class="h-2.5 w-2.5" />CI
+									</a>
+									<a
+										href={buildDatadogTraceSearchUrl(
+											ddInfo.service,
+											ddInfo.env,
+											ddInfo.version || getDisplayVersion(latestEntry.version)
+										)}
+										target="_blank"
+										rel="noopener noreferrer"
+										class="inline-flex items-center gap-0.5 font-medium text-purple-600 hover:underline dark:text-purple-400"
+									>
+										<DatadogLogo class="h-2.5 w-2.5" />Trace
 									</a>
 								{/if}
 							</li>

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isFieldManaged, isFieldManagedByManager, isFieldManagedByOtherManager, parseLinkAnnotations, extractDatadogInfoFromContainers, buildDatadogTestRunsUrl, buildDatadogLogsUrl } from './utils';
+import { isFieldManaged, isFieldManagedByManager, isFieldManagedByOtherManager, parseLinkAnnotations, extractDatadogInfoFromContainers, buildDatadogTestRunsUrl, buildDatadogLogsUrl, buildDatadogTraceSearchUrl } from './utils';
 
 describe('Field Manager Validation', () => {
     describe('isFieldManaged', () => {
@@ -346,5 +346,28 @@ describe('buildDatadogLogsUrl', () => {
         expect(url).toContain(encodeURIComponent('service:my-service'));
         expect(url).toContain(encodeURIComponent('env:production'));
         expect(url).toContain('&live=true');
+    });
+});
+
+describe('buildDatadogTraceSearchUrl', () => {
+    it('should build a URL with service, env, and version', () => {
+        const url = buildDatadogTraceSearchUrl('my-service', 'production', 'v1.0.0');
+        expect(url).toContain('https://app.datadoghq.com/apm/traces?query=');
+        expect(url).toContain(encodeURIComponent('service:my-service'));
+        expect(url).toContain(encodeURIComponent('env:production'));
+        expect(url).toContain(encodeURIComponent('version:v1.0.0'));
+        // `@rollout.test:true` marker is what distinguishes rollout-test
+        // traces from the service Deployment's regular APM traffic; without
+        // it the search would also surface unrelated traffic.
+        expect(url).toContain(encodeURIComponent('@rollout.test:true'));
+    });
+
+    it('should omit the version filter when no version is provided', () => {
+        const url = buildDatadogTraceSearchUrl('my-service', 'staging');
+        expect(url).toContain('https://app.datadoghq.com/apm/traces?query=');
+        expect(url).toContain(encodeURIComponent('service:my-service'));
+        expect(url).toContain(encodeURIComponent('env:staging'));
+        expect(url).toContain(encodeURIComponent('@rollout.test:true'));
+        expect(url).not.toContain(encodeURIComponent('version:'));
     });
 });

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -351,6 +351,29 @@ export function buildDatadogLogsUrl(service: string, env: string): string {
 	return `https://app.datadoghq.com/logs?query=${encodeURIComponent(`service:${service} env:${env}`)}&live=true`;
 }
 
+/**
+ * Datadog APM trace search filtered to spans emitted by the rollout test.
+ *
+ * The rollout-test image (see `tests/rollout/src/instrumentation.ts` in the
+ * caffeine app repo) wraps each Playwright test + step in custom APM spans
+ * tagged `@rollout.test:true`. Pairing that marker with the standard
+ * unified-service tags (`service`, `env`, `version`) narrows the result
+ * to exactly the traces produced by the canary's rollout-test Job — the
+ * service Deployment's regular APM traffic, which carries the same
+ * `service`/`env`/`version` tags but lacks `@rollout.test:true`, is
+ * excluded.
+ *
+ * Each Playwright test produces one trace (root: `rollout_test.test`,
+ * children: `rollout_test.step` per `test.step()` call), so the search
+ * returns one row per test (more on Job retries) and each row drills
+ * into a step-level flame graph.
+ */
+export function buildDatadogTraceSearchUrl(service: string, env: string, version?: string): string {
+	const filters = [`service:${service}`, `env:${env}`, '@rollout.test:true'];
+	if (version) filters.splice(2, 0, `version:${version}`);
+	return `https://app.datadoghq.com/apm/traces?query=${encodeURIComponent(filters.join(' '))}`;
+}
+
 export function getResourceStatus(resource: Kustomization | OCIRepository) {
 	const readyCondition = resource.status?.conditions?.find((c) => c.type === 'Ready');
 	if (!readyCondition) return { status: 'Unknown', color: 'gray' as const };


### PR DESCRIPTION
## Summary

- Adds `buildDatadogTraceSearchUrl(service, env, version?)` next to the existing `buildDatadogLogsUrl` / `buildDatadogTestRunsUrl` helpers in `frontend/src/lib/utils.ts`.
- Renders a third Datadog "Trace" button inside the existing `{#if ddInfo}` block in `DeploymentPipelineCard.svelte`, with identical styling to the existing Logs/CI buttons.
- Adds 2 vitest cases following the existing `buildDatadog*Url` test style.

## Why

Today the per-test row already shows **Logs** + **CI** Datadog buttons when the rollout-test container has `DD_SERVICE`/`DD_ENV`/`DD_VERSION` env vars (extracted via `extractDatadogInfoFromContainers`). This adds a third **Trace** button that opens Datadog APM search filtered to:

```
service:<X> env:<Y> version:<V> @rollout.test:true
```

It pairs with caffeinelabs/app#4430 which adds custom APM spans (`rollout_test.test` per Playwright test, `rollout_test.step` per `test.step()`) that carry the `@rollout.test:true` marker. Together they let an operator reviewing a failed canary click "Trace" → APM search → click any matching trace → step-level flame graph showing exactly where the test broke. Today's CI Visibility view shows test names but not inner detail; this fills that gap.

## Architecture

Mirrors the existing pattern. No new contracts, no new annotations, no special Kubernetes permissions on the rollout-test pod. The `@rollout.test:true` filter discriminates rollout-test traces from the service Deployment's regular APM traffic (which carries the same `service`/`env`/`version` tags but lacks the marker).

The annotation-based `parseLinkAnnotations` path in the same row stays untouched — it's still the right escape hatch for any future link type that doesn't fit the Datadog convention.

## Files

- `frontend/src/lib/utils.ts` — new helper.
- `frontend/src/lib/utils.test.ts` — 2 new cases.
- `frontend/src/lib/components/DeploymentPipelineCard.svelte` — third `<a>` button (Datadog purple, same styling as Logs/CI).

## Test plan

- [x] `npm run test:unit` — 31/31 pass (29 existing + 2 new).
- [x] `npm run check` — same 6 pre-existing errors before and after, none introduced.
- [ ] After both PRs merge: confirm in a real dev rollout that clicking "Trace" lands on the right APM search and that traces show up matching the query.