### PR TITLE
Support rollout environment color themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A web application with a Go Gin backend and Svelte frontend for managing Kuberne
 ## Features
 
 ### Gate Management
+
 The dashboard provides comprehensive gate management for Kubernetes rollouts:
 
 - **Gate Status Display**: Shows the status of all gates for each rollout
@@ -12,12 +13,14 @@ The dashboard provides comprehensive gate management for Kubernetes rollouts:
 - **Gate History**: Track which versions have passed through gates
 
 ### Kustomization Association
+
 Kustomizations can be associated with rollouts using the annotation format:
 `rollout.kuberik.com/substitute.<variable>.from: <rollout>`
 
 This allows the dashboard to find related kustomizations that reference a specific rollout for variable substitution.
 
 **Example:**
+
 ```yaml
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
@@ -29,7 +32,31 @@ metadata:
 
 In this example, the kustomization `hello-world` is associated with the rollout `hello-world-app` and will receive the `HELLO_WORLD_VERSION` variable from that rollout.
 
+### Environment Color Themes
+
+Rollouts can opt into dashboard color themes with annotations on the Rollout resource. This helps distinguish environments when switching between development, staging, and production dashboards.
+
+```yaml
+apiVersion: kuberik.com/v1alpha1
+kind: Rollout
+metadata:
+  name: hello-world-app
+  annotations:
+    # Presets: dev/development, staging, prod/production, test/testing
+    dashboard.rollout.kuberik.com/theme: "prod"
+```
+
+Production uses an amber preset instead of red so it does not look like an error state. For fully custom themes, set a validated hex color and optional label:
+
+```yaml
+metadata:
+  annotations:
+    dashboard.rollout.kuberik.com/theme-color: "#0ea5e9"
+    dashboard.rollout.kuberik.com/theme-label: "Sandbox"
+```
+
 ### Bypass Gates Feature
+
 You can allow the rollout controller to bypass gate checks for a specific version by adding the `rollout.kuberik.com/bypass-gates` annotation with the version as the value:
 
 ```bash
@@ -60,11 +87,13 @@ kubectl annotate rollout <rollout-name> rollout.kuberik.com/bypass-gates-
 ### Backend (Go)
 
 1. Install Go dependencies:
+
 ```bash
 go mod tidy
 ```
 
 2. Run the backend server:
+
 ```bash
 go run main.go
 ```
@@ -74,16 +103,19 @@ The backend server will run on http://localhost:8080
 ### Frontend (Svelte)
 
 1. Navigate to the frontend directory:
+
 ```bash
 cd frontend
 ```
 
 2. Install dependencies:
+
 ```bash
 npm install
 ```
 
 3. Run the development server:
+
 ```bash
 npm run dev
 ```
@@ -93,6 +125,7 @@ The frontend development server will run on http://localhost:5173
 ## Building for Production
 
 1. Build the frontend:
+
 ```bash
 cd frontend
 npm run build

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ In this example, the kustomization `hello-world` is associated with the rollout 
 
 ### Environment Color Themes
 
-Rollouts can opt into dashboard color themes with annotations on the Rollout resource. This helps distinguish environments when switching between development, staging, and production dashboards.
+The dashboard can infer a rollout's color theme from its related Environment resource. If `spec.environment` contains `prod` or `production`, the dashboard uses the production theme; names containing `dev`, `development`, `staging`, `stage`, `test`, or `testing` use their matching presets.
+
+Rollouts can also opt into or override dashboard color themes with annotations on the Rollout resource. This helps distinguish environments when switching between development, staging, and production dashboards, including in places where Environment data is not loaded.
 
 ```yaml
 apiVersion: kuberik.com/v1alpha1

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ In this example, the kustomization `hello-world` is associated with the rollout 
 
 The dashboard can infer a rollout's color theme from its related Environment resource. If `spec.environment` contains `prod` or `production`, the dashboard uses the production theme; names containing `dev`, `development`, `staging`, `stage`, `test`, or `testing` use their matching presets.
 
-Rollouts can also opt into or override dashboard color themes with annotations on the Rollout resource. This helps distinguish environments when switching between development, staging, and production dashboards, including in places where Environment data is not loaded.
+Rollouts can also opt into or override dashboard color themes with annotations on the Rollout resource. When present, annotation values take precedence over Environment inference. This helps distinguish environments when switching between development, staging, and production dashboards, including in places where Environment data is not loaded.
 
 ```yaml
 apiVersion: kuberik.com/v1alpha1

--- a/example/hello-multi/cd/base/resources.yaml
+++ b/example/hello-multi/cd/base/resources.yaml
@@ -10,6 +10,7 @@ metadata:
   name: hello-multi-app
   annotations:
     dashboard.rollout.kuberik.com/description: "Hello Multi app / __ENVIRONMENT__"
+    dashboard.rollout.kuberik.com/theme: "__ENVIRONMENT__"
 spec:
   releasesImagePolicy:
     name: hello-multi-app

--- a/example/hello-multi/cd/deployments/dev/kustomization.yaml
+++ b/example/hello-multi/cd/deployments/dev/kustomization.yaml
@@ -24,6 +24,11 @@ replacements:
           delimiter: " "
           index: 4
       - select:
+          kind: Rollout
+          name: hello-multi-app
+        fieldPaths:
+          - metadata.annotations.[dashboard.rollout.kuberik.com/theme]
+      - select:
           kind: OCIRepository
           name: hello-multi
         fieldPaths:

--- a/example/hello-multi/cd/deployments/prod/kustomization.yaml
+++ b/example/hello-multi/cd/deployments/prod/kustomization.yaml
@@ -24,6 +24,11 @@ replacements:
           delimiter: " "
           index: 4
       - select:
+          kind: Rollout
+          name: hello-multi-app
+        fieldPaths:
+          - metadata.annotations.[dashboard.rollout.kuberik.com/theme]
+      - select:
           kind: OCIRepository
           name: hello-multi
         fieldPaths:

--- a/example/hello-multi/cd/deployments/staging/kustomization.yaml
+++ b/example/hello-multi/cd/deployments/staging/kustomization.yaml
@@ -24,6 +24,11 @@ replacements:
           delimiter: " "
           index: 4
       - select:
+          kind: Rollout
+          name: hello-multi-app
+        fieldPaths:
+          - metadata.annotations.[dashboard.rollout.kuberik.com/theme]
+      - select:
           kind: OCIRepository
           name: hello-multi
         fieldPaths:

--- a/example/hello-world/cd/base/resources.yaml
+++ b/example/hello-world/cd/base/resources.yaml
@@ -10,6 +10,7 @@ metadata:
   name: hello-world-manifests
   annotations:
     dashboard.rollout.kuberik.com/description: "Hello World manifests / __ENVIRONMENT__"
+    dashboard.rollout.kuberik.com/theme: "__ENVIRONMENT__"
 spec:
   releasesImagePolicy:
     name: hello-world-manifests
@@ -74,9 +75,10 @@ kind: Rollout
 metadata:
   name: hello-world-app
   labels:
-    schedule: business-hours  # This rollout is controlled by business-hours schedule
+    schedule: business-hours # This rollout is controlled by business-hours schedule
   annotations:
     dashboard.rollout.kuberik.com/description: "Hello World app / __ENVIRONMENT__"
+    dashboard.rollout.kuberik.com/theme: "__ENVIRONMENT__"
 spec:
   releasesImagePolicy:
     name: hello-world-app

--- a/example/hello-world/cd/deployments/dev/kustomization.yaml
+++ b/example/hello-world/cd/deployments/dev/kustomization.yaml
@@ -23,6 +23,10 @@ replacements:
           delimiter: " "
           index: 4
       - select:
+          kind: Rollout
+        fieldPaths:
+          - metadata.annotations.[dashboard.rollout.kuberik.com/theme]
+      - select:
           kind: ImageRepository
           name: hello-world-manifests
         fieldPaths:

--- a/example/hello-world/cd/deployments/prod/kustomization.yaml
+++ b/example/hello-world/cd/deployments/prod/kustomization.yaml
@@ -24,6 +24,10 @@ replacements:
           delimiter: " "
           index: 4
       - select:
+          kind: Rollout
+        fieldPaths:
+          - metadata.annotations.[dashboard.rollout.kuberik.com/theme]
+      - select:
           kind: ImageRepository
           name: hello-world-manifests
         fieldPaths:

--- a/example/hello-world/cd/deployments/staging/kustomization.yaml
+++ b/example/hello-world/cd/deployments/staging/kustomization.yaml
@@ -23,6 +23,10 @@ replacements:
           delimiter: " "
           index: 4
       - select:
+          kind: Rollout
+        fieldPaths:
+          - metadata.annotations.[dashboard.rollout.kuberik.com/theme]
+      - select:
           kind: ImageRepository
           name: hello-world-manifests
         fieldPaths:

--- a/frontend/dev-mock-api.ts
+++ b/frontend/dev-mock-api.ts
@@ -209,10 +209,7 @@ const mockManagedResources = {
 										env: [
 											{ name: 'DD_SERVICE', value: ROLLOUT_NAME },
 											{ name: 'DD_ENV', value: 'dev' },
-											{
-												name: 'DD_VERSION',
-												value: 'main-1770831919-f68d0ac3ed1185943c9105df735a099a2165c7ce'
-											}
+											{ name: 'DD_VERSION', value: 'main-1770831919-f68d0ac3ed1185943c9105df735a099a2165c7ce' }
 										]
 									}
 								]
@@ -320,103 +317,37 @@ export function mockApiPlugin(): Plugin {
 
 					// Sample log lines for realistic output
 					const sampleLogs = [
-						{
-							level: 'INFO',
-							msg: 'Starting server on :8080 with configuration loaded from /etc/config/app.yaml, environment=production, region=eu-west-1, instance_id=i-0a1b2c3d4e5f6g7h8'
-						},
-						{
-							level: 'INFO',
-							msg: 'Connected to database postgresql://db.internal.cluster.local:5432/hello_world?sslmode=require&connect_timeout=10&application_name=hello-world-api-server'
-						},
-						{
-							level: 'DEBUG',
-							msg: 'Loading configuration from /etc/config/app.yaml: database.pool_size=25, database.max_idle=5, cache.ttl=300s, cache.backend=redis, tracing.enabled=true, tracing.sample_rate=0.1'
-						},
-						{
-							level: 'INFO',
-							msg: 'Health check endpoint registered at /healthz | Readiness probe: /ready | Liveness probe: /alive | Startup probe: /startup (timeout: 30s)'
-						},
-						{
-							level: 'INFO',
-							msg: 'Metrics endpoint registered at /metrics (prometheus format) | Custom metrics: http_requests_total, http_request_duration_seconds, db_query_duration_seconds, cache_hit_ratio'
-						},
-						{
-							level: 'INFO',
-							msg: 'Ready to accept connections on 0.0.0.0:8080 (HTTP) and 0.0.0.0:8443 (HTTPS) | TLS certificate loaded from /etc/tls/tls.crt, key from /etc/tls/tls.key'
-						},
-						{
-							level: 'INFO',
-							msg: 'GET /api/v1/users?page=1&limit=50&sort=created_at&order=desc 200 12ms | request_id=req_a1b2c3d4 | user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)" | ip=10.244.3.15'
-						},
-						{
-							level: 'DEBUG',
-							msg: 'Cache hit for key: users:list:page=1:limit=50:sort=created_at:order=desc | cache_backend=redis | ttl_remaining=245s | size=12.4KB | compression=gzip'
-						},
-						{
-							level: 'INFO',
-							msg: 'POST /api/v1/orders 201 45ms | request_id=req_e5f6g7h8 | order_id=ord_9f8e7d6c | total=149.99 | currency=EUR | items=3 | payment_method=stripe'
-						},
-						{
-							level: 'WARN',
-							msg: 'Slow query detected: SELECT o.*, u.name, u.email FROM orders o JOIN users u ON o.user_id = u.id WHERE o.status = $1 AND o.created_at > $2 ORDER BY o.created_at DESC LIMIT 100 -- execution_time=320ms threshold=200ms rows_returned=87'
-						},
-						{
-							level: 'INFO',
-							msg: 'GET /api/v1/products?category=electronics&brand=samsung&min_price=100&max_price=2000&in_stock=true&sort=popularity 200 8ms | results=142 | cache=HIT'
-						},
-						{
-							level: 'ERROR',
-							msg: 'Failed to connect to redis at redis-master.cache.svc.cluster.local:6379 - ECONNREFUSED | retry_attempt=3/5 | backoff=8s | last_successful_connection=2m30s ago | pending_operations=12'
-						},
-						{
-							level: 'INFO',
-							msg: 'Retrying redis connection in 5s... | connection_pool: active=0/25 idle=0/5 | fallback_mode=local_cache | degraded_features=[session_store, rate_limiter, pub_sub]'
-						},
-						{
-							level: 'INFO',
-							msg: 'Redis connection re-established to redis-master.cache.svc.cluster.local:6379 | latency=2.3ms | pool_recovered: active=3/25 idle=5/5 | replaying 12 buffered operations'
-						},
-						{
-							level: 'DEBUG',
-							msg: 'Processing webhook payload: {"event":"order.completed","id":"ord_9f8e7d6c","customer_id":"cust_x1y2z3","amount":149.99,"currency":"EUR","items":[{"sku":"SKU-001","qty":1},{"sku":"SKU-042","qty":2}],"metadata":{"source":"web","campaign":"summer-sale"}}'
-						},
-						{
-							level: 'INFO',
-							msg: 'GET /healthz 200 1ms | checks: database=ok(2ms) redis=ok(1ms) disk=ok(89% free) memory=ok(654MB/1024MB) goroutines=142 uptime=4h23m'
-						},
-						{
-							level: 'INFO',
-							msg: 'Graceful shutdown initiated (SIGTERM received), draining 23 active connections... | in_flight_requests=23 | drain_timeout=30s | active_websockets=5 | background_jobs=3'
-						},
-						{
-							level: 'INFO',
-							msg: 'All connections drained successfully in 2.4s, shutting down HTTP server | total_requests_served=1,284,567 | uptime=4h23m12s | avg_response_time=18ms'
-						},
-						{
-							level: 'WARN',
-							msg: 'High memory usage detected: 892MB / 1024MB (87%) | heap_alloc=756MB heap_sys=892MB stack_inuse=12MB gc_pause_avg=4.2ms num_goroutines=342 | consider increasing memory limit'
-						},
-						{
-							level: 'INFO',
-							msg: 'GC completed: freed 245MB in 12ms | before=892MB after=647MB | next_gc_target=780MB | total_gc_cycles=1847 | cpu_fraction=0.02%'
-						}
+						{ level: 'INFO', msg: 'Starting server on :8080 with configuration loaded from /etc/config/app.yaml, environment=production, region=eu-west-1, instance_id=i-0a1b2c3d4e5f6g7h8' },
+						{ level: 'INFO', msg: 'Connected to database postgresql://db.internal.cluster.local:5432/hello_world?sslmode=require&connect_timeout=10&application_name=hello-world-api-server' },
+						{ level: 'DEBUG', msg: 'Loading configuration from /etc/config/app.yaml: database.pool_size=25, database.max_idle=5, cache.ttl=300s, cache.backend=redis, tracing.enabled=true, tracing.sample_rate=0.1' },
+						{ level: 'INFO', msg: 'Health check endpoint registered at /healthz | Readiness probe: /ready | Liveness probe: /alive | Startup probe: /startup (timeout: 30s)' },
+						{ level: 'INFO', msg: 'Metrics endpoint registered at /metrics (prometheus format) | Custom metrics: http_requests_total, http_request_duration_seconds, db_query_duration_seconds, cache_hit_ratio' },
+						{ level: 'INFO', msg: 'Ready to accept connections on 0.0.0.0:8080 (HTTP) and 0.0.0.0:8443 (HTTPS) | TLS certificate loaded from /etc/tls/tls.crt, key from /etc/tls/tls.key' },
+						{ level: 'INFO', msg: 'GET /api/v1/users?page=1&limit=50&sort=created_at&order=desc 200 12ms | request_id=req_a1b2c3d4 | user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)" | ip=10.244.3.15' },
+						{ level: 'DEBUG', msg: 'Cache hit for key: users:list:page=1:limit=50:sort=created_at:order=desc | cache_backend=redis | ttl_remaining=245s | size=12.4KB | compression=gzip' },
+						{ level: 'INFO', msg: 'POST /api/v1/orders 201 45ms | request_id=req_e5f6g7h8 | order_id=ord_9f8e7d6c | total=149.99 | currency=EUR | items=3 | payment_method=stripe' },
+						{ level: 'WARN', msg: 'Slow query detected: SELECT o.*, u.name, u.email FROM orders o JOIN users u ON o.user_id = u.id WHERE o.status = $1 AND o.created_at > $2 ORDER BY o.created_at DESC LIMIT 100 -- execution_time=320ms threshold=200ms rows_returned=87' },
+						{ level: 'INFO', msg: 'GET /api/v1/products?category=electronics&brand=samsung&min_price=100&max_price=2000&in_stock=true&sort=popularity 200 8ms | results=142 | cache=HIT' },
+						{ level: 'ERROR', msg: 'Failed to connect to redis at redis-master.cache.svc.cluster.local:6379 - ECONNREFUSED | retry_attempt=3/5 | backoff=8s | last_successful_connection=2m30s ago | pending_operations=12' },
+						{ level: 'INFO', msg: 'Retrying redis connection in 5s... | connection_pool: active=0/25 idle=0/5 | fallback_mode=local_cache | degraded_features=[session_store, rate_limiter, pub_sub]' },
+						{ level: 'INFO', msg: 'Redis connection re-established to redis-master.cache.svc.cluster.local:6379 | latency=2.3ms | pool_recovered: active=3/25 idle=5/5 | replaying 12 buffered operations' },
+						{ level: 'DEBUG', msg: 'Processing webhook payload: {"event":"order.completed","id":"ord_9f8e7d6c","customer_id":"cust_x1y2z3","amount":149.99,"currency":"EUR","items":[{"sku":"SKU-001","qty":1},{"sku":"SKU-042","qty":2}],"metadata":{"source":"web","campaign":"summer-sale"}}' },
+						{ level: 'INFO', msg: 'GET /healthz 200 1ms | checks: database=ok(2ms) redis=ok(1ms) disk=ok(89% free) memory=ok(654MB/1024MB) goroutines=142 uptime=4h23m' },
+						{ level: 'INFO', msg: 'Graceful shutdown initiated (SIGTERM received), draining 23 active connections... | in_flight_requests=23 | drain_timeout=30s | active_websockets=5 | background_jobs=3' },
+						{ level: 'INFO', msg: 'All connections drained successfully in 2.4s, shutting down HTTP server | total_requests_served=1,284,567 | uptime=4h23m12s | avg_response_time=18ms' },
+						{ level: 'WARN', msg: 'High memory usage detected: 892MB / 1024MB (87%) | heap_alloc=756MB heap_sys=892MB stack_inuse=12MB gc_pause_avg=4.2ms num_goroutines=342 | consider increasing memory limit' },
+						{ level: 'INFO', msg: 'GC completed: freed 245MB in 12ms | before=892MB after=647MB | next_gc_target=780MB | total_gc_cycles=1847 | cpu_fraction=0.02%' },
 					];
 
 					const testLogs = [
 						{ level: 'INFO', msg: 'Running test suite: integration' },
 						{ level: 'INFO', msg: 'Test: health check endpoint ... PASSED (2ms)' },
 						{ level: 'INFO', msg: 'Test: create user ... PASSED (145ms)' },
-						{
-							level: 'WARN',
-							msg: 'Test: update user with invalid email ... PASSED (12ms) [expected 400]'
-						},
+						{ level: 'WARN', msg: 'Test: update user with invalid email ... PASSED (12ms) [expected 400]' },
 						{ level: 'INFO', msg: 'Test: list orders with pagination ... PASSED (89ms)' },
-						{
-							level: 'ERROR',
-							msg: 'Test: concurrent writes ... FAILED: expected 200 but got 409 Conflict'
-						},
+						{ level: 'ERROR', msg: 'Test: concurrent writes ... FAILED: expected 200 but got 409 Conflict' },
 						{ level: 'INFO', msg: 'Test: delete expired sessions ... PASSED (234ms)' },
-						{ level: 'INFO', msg: 'Test suite completed: 6/7 passed, 1 failed' }
+						{ level: 'INFO', msg: 'Test suite completed: 6/7 passed, 1 failed' },
 					];
 
 					let logIndex = 0;

--- a/frontend/dev-mock-api.ts
+++ b/frontend/dev-mock-api.ts
@@ -30,7 +30,8 @@ const mockRolloutResponse = {
 			namespace: NAMESPACE,
 			annotations: {
 				'dashboard.rollout.kuberik.com/description':
-					'Example application for testing rollout features.'
+					'Example application for testing rollout features.',
+				'dashboard.rollout.kuberik.com/theme': 'dev'
 			},
 			labels: {
 				environment: 'dev'
@@ -208,7 +209,10 @@ const mockManagedResources = {
 										env: [
 											{ name: 'DD_SERVICE', value: ROLLOUT_NAME },
 											{ name: 'DD_ENV', value: 'dev' },
-											{ name: 'DD_VERSION', value: 'main-1770831919-f68d0ac3ed1185943c9105df735a099a2165c7ce' }
+											{
+												name: 'DD_VERSION',
+												value: 'main-1770831919-f68d0ac3ed1185943c9105df735a099a2165c7ce'
+											}
 										]
 									}
 								]
@@ -316,37 +320,103 @@ export function mockApiPlugin(): Plugin {
 
 					// Sample log lines for realistic output
 					const sampleLogs = [
-						{ level: 'INFO', msg: 'Starting server on :8080 with configuration loaded from /etc/config/app.yaml, environment=production, region=eu-west-1, instance_id=i-0a1b2c3d4e5f6g7h8' },
-						{ level: 'INFO', msg: 'Connected to database postgresql://db.internal.cluster.local:5432/hello_world?sslmode=require&connect_timeout=10&application_name=hello-world-api-server' },
-						{ level: 'DEBUG', msg: 'Loading configuration from /etc/config/app.yaml: database.pool_size=25, database.max_idle=5, cache.ttl=300s, cache.backend=redis, tracing.enabled=true, tracing.sample_rate=0.1' },
-						{ level: 'INFO', msg: 'Health check endpoint registered at /healthz | Readiness probe: /ready | Liveness probe: /alive | Startup probe: /startup (timeout: 30s)' },
-						{ level: 'INFO', msg: 'Metrics endpoint registered at /metrics (prometheus format) | Custom metrics: http_requests_total, http_request_duration_seconds, db_query_duration_seconds, cache_hit_ratio' },
-						{ level: 'INFO', msg: 'Ready to accept connections on 0.0.0.0:8080 (HTTP) and 0.0.0.0:8443 (HTTPS) | TLS certificate loaded from /etc/tls/tls.crt, key from /etc/tls/tls.key' },
-						{ level: 'INFO', msg: 'GET /api/v1/users?page=1&limit=50&sort=created_at&order=desc 200 12ms | request_id=req_a1b2c3d4 | user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)" | ip=10.244.3.15' },
-						{ level: 'DEBUG', msg: 'Cache hit for key: users:list:page=1:limit=50:sort=created_at:order=desc | cache_backend=redis | ttl_remaining=245s | size=12.4KB | compression=gzip' },
-						{ level: 'INFO', msg: 'POST /api/v1/orders 201 45ms | request_id=req_e5f6g7h8 | order_id=ord_9f8e7d6c | total=149.99 | currency=EUR | items=3 | payment_method=stripe' },
-						{ level: 'WARN', msg: 'Slow query detected: SELECT o.*, u.name, u.email FROM orders o JOIN users u ON o.user_id = u.id WHERE o.status = $1 AND o.created_at > $2 ORDER BY o.created_at DESC LIMIT 100 -- execution_time=320ms threshold=200ms rows_returned=87' },
-						{ level: 'INFO', msg: 'GET /api/v1/products?category=electronics&brand=samsung&min_price=100&max_price=2000&in_stock=true&sort=popularity 200 8ms | results=142 | cache=HIT' },
-						{ level: 'ERROR', msg: 'Failed to connect to redis at redis-master.cache.svc.cluster.local:6379 - ECONNREFUSED | retry_attempt=3/5 | backoff=8s | last_successful_connection=2m30s ago | pending_operations=12' },
-						{ level: 'INFO', msg: 'Retrying redis connection in 5s... | connection_pool: active=0/25 idle=0/5 | fallback_mode=local_cache | degraded_features=[session_store, rate_limiter, pub_sub]' },
-						{ level: 'INFO', msg: 'Redis connection re-established to redis-master.cache.svc.cluster.local:6379 | latency=2.3ms | pool_recovered: active=3/25 idle=5/5 | replaying 12 buffered operations' },
-						{ level: 'DEBUG', msg: 'Processing webhook payload: {"event":"order.completed","id":"ord_9f8e7d6c","customer_id":"cust_x1y2z3","amount":149.99,"currency":"EUR","items":[{"sku":"SKU-001","qty":1},{"sku":"SKU-042","qty":2}],"metadata":{"source":"web","campaign":"summer-sale"}}' },
-						{ level: 'INFO', msg: 'GET /healthz 200 1ms | checks: database=ok(2ms) redis=ok(1ms) disk=ok(89% free) memory=ok(654MB/1024MB) goroutines=142 uptime=4h23m' },
-						{ level: 'INFO', msg: 'Graceful shutdown initiated (SIGTERM received), draining 23 active connections... | in_flight_requests=23 | drain_timeout=30s | active_websockets=5 | background_jobs=3' },
-						{ level: 'INFO', msg: 'All connections drained successfully in 2.4s, shutting down HTTP server | total_requests_served=1,284,567 | uptime=4h23m12s | avg_response_time=18ms' },
-						{ level: 'WARN', msg: 'High memory usage detected: 892MB / 1024MB (87%) | heap_alloc=756MB heap_sys=892MB stack_inuse=12MB gc_pause_avg=4.2ms num_goroutines=342 | consider increasing memory limit' },
-						{ level: 'INFO', msg: 'GC completed: freed 245MB in 12ms | before=892MB after=647MB | next_gc_target=780MB | total_gc_cycles=1847 | cpu_fraction=0.02%' },
+						{
+							level: 'INFO',
+							msg: 'Starting server on :8080 with configuration loaded from /etc/config/app.yaml, environment=production, region=eu-west-1, instance_id=i-0a1b2c3d4e5f6g7h8'
+						},
+						{
+							level: 'INFO',
+							msg: 'Connected to database postgresql://db.internal.cluster.local:5432/hello_world?sslmode=require&connect_timeout=10&application_name=hello-world-api-server'
+						},
+						{
+							level: 'DEBUG',
+							msg: 'Loading configuration from /etc/config/app.yaml: database.pool_size=25, database.max_idle=5, cache.ttl=300s, cache.backend=redis, tracing.enabled=true, tracing.sample_rate=0.1'
+						},
+						{
+							level: 'INFO',
+							msg: 'Health check endpoint registered at /healthz | Readiness probe: /ready | Liveness probe: /alive | Startup probe: /startup (timeout: 30s)'
+						},
+						{
+							level: 'INFO',
+							msg: 'Metrics endpoint registered at /metrics (prometheus format) | Custom metrics: http_requests_total, http_request_duration_seconds, db_query_duration_seconds, cache_hit_ratio'
+						},
+						{
+							level: 'INFO',
+							msg: 'Ready to accept connections on 0.0.0.0:8080 (HTTP) and 0.0.0.0:8443 (HTTPS) | TLS certificate loaded from /etc/tls/tls.crt, key from /etc/tls/tls.key'
+						},
+						{
+							level: 'INFO',
+							msg: 'GET /api/v1/users?page=1&limit=50&sort=created_at&order=desc 200 12ms | request_id=req_a1b2c3d4 | user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)" | ip=10.244.3.15'
+						},
+						{
+							level: 'DEBUG',
+							msg: 'Cache hit for key: users:list:page=1:limit=50:sort=created_at:order=desc | cache_backend=redis | ttl_remaining=245s | size=12.4KB | compression=gzip'
+						},
+						{
+							level: 'INFO',
+							msg: 'POST /api/v1/orders 201 45ms | request_id=req_e5f6g7h8 | order_id=ord_9f8e7d6c | total=149.99 | currency=EUR | items=3 | payment_method=stripe'
+						},
+						{
+							level: 'WARN',
+							msg: 'Slow query detected: SELECT o.*, u.name, u.email FROM orders o JOIN users u ON o.user_id = u.id WHERE o.status = $1 AND o.created_at > $2 ORDER BY o.created_at DESC LIMIT 100 -- execution_time=320ms threshold=200ms rows_returned=87'
+						},
+						{
+							level: 'INFO',
+							msg: 'GET /api/v1/products?category=electronics&brand=samsung&min_price=100&max_price=2000&in_stock=true&sort=popularity 200 8ms | results=142 | cache=HIT'
+						},
+						{
+							level: 'ERROR',
+							msg: 'Failed to connect to redis at redis-master.cache.svc.cluster.local:6379 - ECONNREFUSED | retry_attempt=3/5 | backoff=8s | last_successful_connection=2m30s ago | pending_operations=12'
+						},
+						{
+							level: 'INFO',
+							msg: 'Retrying redis connection in 5s... | connection_pool: active=0/25 idle=0/5 | fallback_mode=local_cache | degraded_features=[session_store, rate_limiter, pub_sub]'
+						},
+						{
+							level: 'INFO',
+							msg: 'Redis connection re-established to redis-master.cache.svc.cluster.local:6379 | latency=2.3ms | pool_recovered: active=3/25 idle=5/5 | replaying 12 buffered operations'
+						},
+						{
+							level: 'DEBUG',
+							msg: 'Processing webhook payload: {"event":"order.completed","id":"ord_9f8e7d6c","customer_id":"cust_x1y2z3","amount":149.99,"currency":"EUR","items":[{"sku":"SKU-001","qty":1},{"sku":"SKU-042","qty":2}],"metadata":{"source":"web","campaign":"summer-sale"}}'
+						},
+						{
+							level: 'INFO',
+							msg: 'GET /healthz 200 1ms | checks: database=ok(2ms) redis=ok(1ms) disk=ok(89% free) memory=ok(654MB/1024MB) goroutines=142 uptime=4h23m'
+						},
+						{
+							level: 'INFO',
+							msg: 'Graceful shutdown initiated (SIGTERM received), draining 23 active connections... | in_flight_requests=23 | drain_timeout=30s | active_websockets=5 | background_jobs=3'
+						},
+						{
+							level: 'INFO',
+							msg: 'All connections drained successfully in 2.4s, shutting down HTTP server | total_requests_served=1,284,567 | uptime=4h23m12s | avg_response_time=18ms'
+						},
+						{
+							level: 'WARN',
+							msg: 'High memory usage detected: 892MB / 1024MB (87%) | heap_alloc=756MB heap_sys=892MB stack_inuse=12MB gc_pause_avg=4.2ms num_goroutines=342 | consider increasing memory limit'
+						},
+						{
+							level: 'INFO',
+							msg: 'GC completed: freed 245MB in 12ms | before=892MB after=647MB | next_gc_target=780MB | total_gc_cycles=1847 | cpu_fraction=0.02%'
+						}
 					];
 
 					const testLogs = [
 						{ level: 'INFO', msg: 'Running test suite: integration' },
 						{ level: 'INFO', msg: 'Test: health check endpoint ... PASSED (2ms)' },
 						{ level: 'INFO', msg: 'Test: create user ... PASSED (145ms)' },
-						{ level: 'WARN', msg: 'Test: update user with invalid email ... PASSED (12ms) [expected 400]' },
+						{
+							level: 'WARN',
+							msg: 'Test: update user with invalid email ... PASSED (12ms) [expected 400]'
+						},
 						{ level: 'INFO', msg: 'Test: list orders with pagination ... PASSED (89ms)' },
-						{ level: 'ERROR', msg: 'Test: concurrent writes ... FAILED: expected 200 but got 409 Conflict' },
+						{
+							level: 'ERROR',
+							msg: 'Test: concurrent writes ... FAILED: expected 200 but got 409 Conflict'
+						},
 						{ level: 'INFO', msg: 'Test: delete expired sessions ... PASSED (234ms)' },
-						{ level: 'INFO', msg: 'Test suite completed: 6/7 passed, 1 failed' },
+						{ level: 'INFO', msg: 'Test suite completed: 6/7 passed, 1 failed' }
 					];
 
 					let logIndex = 0;

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -81,13 +81,10 @@ input, select, textarea {
   color: var(--rollout-theme-text);
 }
 
-.environment-theme-card {
-  border-color: var(--rollout-theme-border);
-  background-color: color-mix(in srgb, var(--rollout-theme-surface) 65%, white);
-}
-
-.environment-theme-card:hover {
-  border-color: color-mix(in srgb, var(--rollout-theme-accent) 55%, white);
+.environment-theme-badge {
+  border: 1px solid var(--rollout-theme-border);
+  background-color: color-mix(in srgb, var(--rollout-theme-surface) 72%, transparent);
+  color: var(--rollout-theme-text);
 }
 
 .dark .environment-theme-text {
@@ -99,13 +96,10 @@ input, select, textarea {
   color: var(--rollout-theme-dark-text);
 }
 
-.dark .environment-theme-card {
-  border-color: color-mix(in srgb, var(--rollout-theme-accent) 40%, rgb(55 65 81));
-  background-color: color-mix(in srgb, var(--rollout-theme-dark-surface) 28%, rgb(31 41 55));
-}
-
-.dark .environment-theme-card:hover {
-  border-color: color-mix(in srgb, var(--rollout-theme-accent) 55%, rgb(55 65 81));
+.dark .environment-theme-badge {
+  border-color: color-mix(in srgb, var(--rollout-theme-accent) 38%, rgb(55 65 81));
+  background-color: color-mix(in srgb, var(--rollout-theme-dark-surface) 28%, transparent);
+  color: var(--rollout-theme-dark-text);
 }
 
 .dark {

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -1,4 +1,4 @@
-@import 'tailwindcss';
+@import "tailwindcss";
 
 @plugin 'flowbite/plugin';
 
@@ -8,158 +8,158 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 @theme {
-	--color-primary-50: #fff5f2;
-	--color-primary-100: #fff1ee;
-	--color-primary-200: #ffe4de;
-	--color-primary-300: #ffd5cc;
-	--color-primary-400: #ffbcad;
-	--color-primary-500: #fe795d;
-	--color-primary-600: #ef562f;
-	--color-primary-700: #eb4f27;
-	--color-primary-800: #cc4522;
-	--color-primary-900: #a5371b;
+  --color-primary-50: #fff5f2;
+  --color-primary-100: #fff1ee;
+  --color-primary-200: #ffe4de;
+  --color-primary-300: #ffd5cc;
+  --color-primary-400: #ffbcad;
+  --color-primary-500: #fe795d;
+  --color-primary-600: #ef562f;
+  --color-primary-700: #eb4f27;
+  --color-primary-800: #cc4522;
+  --color-primary-900: #a5371b;
 
-	--color-secondary-50: #f0f9ff;
-	--color-secondary-100: #e0f2fe;
-	--color-secondary-200: #bae6fd;
-	--color-secondary-300: #7dd3fc;
-	--color-secondary-400: #38bdf8;
-	--color-secondary-500: #0ea5e9;
-	--color-secondary-600: #0284c7;
-	--color-secondary-700: #0369a1;
-	--color-secondary-800: #075985;
-	--color-secondary-900: #0c4a6e;
+  --color-secondary-50: #f0f9ff;
+  --color-secondary-100: #e0f2fe;
+  --color-secondary-200: #bae6fd;
+  --color-secondary-300: #7dd3fc;
+  --color-secondary-400: #38bdf8;
+  --color-secondary-500: #0ea5e9;
+  --color-secondary-600: #0284c7;
+  --color-secondary-700: #0369a1;
+  --color-secondary-800: #075985;
+  --color-secondary-900: #0c4a6e;
 
-	--font-montserrat: 'Montserrat', sans-serif;
+  --font-montserrat: "Montserrat", sans-serif;
 }
 
 @source "../node_modules/flowbite-svelte/dist";
 @source "../node_modules/flowbite-svelte-icons/dist";
 
 @layer base {
-	button,
-	[role='button'] {
-		cursor: pointer;
-	}
 
-	/* disable chrome cancel button */
-	input[type='search']::-webkit-search-cancel-button {
-		display: none;
-	}
+  button,
+  [role="button"] {
+    cursor: pointer;
+  }
+
+  /* disable chrome cancel button */
+  input[type="search"]::-webkit-search-cancel-button {
+    display: none;
+  }
+
 }
 
 /* prevent iOS Safari from zooming on input focus — must be unlayered to beat Tailwind utilities */
-input,
-select,
-textarea {
-	font-size: max(16px, 1em);
+input, select, textarea {
+  font-size: max(16px, 1em);
 }
 
 .environment-theme-scope {
-	--rollout-theme-accent: #2563eb;
-	--rollout-theme-text: #1d4ed8;
-	--rollout-theme-border: #bfdbfe;
-	--rollout-theme-surface: #eff6ff;
-	--rollout-theme-dark-surface: #172554;
-	--rollout-theme-dark-text: #93c5fd;
+  --rollout-theme-accent: #2563eb;
+  --rollout-theme-text: #1d4ed8;
+  --rollout-theme-border: #bfdbfe;
+  --rollout-theme-surface: #eff6ff;
+  --rollout-theme-dark-surface: #172554;
+  --rollout-theme-dark-text: #93c5fd;
 }
 
 .environment-theme-accent {
-	background-color: var(--rollout-theme-accent);
+  background-color: var(--rollout-theme-accent);
 }
 
 .environment-theme-text {
-	color: var(--rollout-theme-text);
+  color: var(--rollout-theme-text);
 }
 
 .environment-theme-border {
-	border-color: var(--rollout-theme-border);
+  border-color: var(--rollout-theme-border);
 }
 
 .environment-theme-surface {
-	background-color: var(--rollout-theme-surface);
-	color: var(--rollout-theme-text);
+  background-color: var(--rollout-theme-surface);
+  color: var(--rollout-theme-text);
 }
 
 .environment-theme-card {
-	border-color: var(--rollout-theme-border);
-	background-color: color-mix(in srgb, var(--rollout-theme-surface) 65%, white);
+  border-color: var(--rollout-theme-border);
+  background-color: color-mix(in srgb, var(--rollout-theme-surface) 65%, white);
 }
 
 .environment-theme-card:hover {
-	border-color: color-mix(in srgb, var(--rollout-theme-accent) 55%, white);
+  border-color: color-mix(in srgb, var(--rollout-theme-accent) 55%, white);
 }
 
 .dark .environment-theme-text {
-	color: var(--rollout-theme-dark-text);
+  color: var(--rollout-theme-dark-text);
 }
 
 .dark .environment-theme-surface {
-	background-color: color-mix(in srgb, var(--rollout-theme-dark-surface) 45%, transparent);
-	color: var(--rollout-theme-dark-text);
+  background-color: color-mix(in srgb, var(--rollout-theme-dark-surface) 45%, transparent);
+  color: var(--rollout-theme-dark-text);
 }
 
 .dark .environment-theme-card {
-	border-color: color-mix(in srgb, var(--rollout-theme-accent) 40%, rgb(55 65 81));
-	background-color: color-mix(in srgb, var(--rollout-theme-dark-surface) 28%, rgb(31 41 55));
+  border-color: color-mix(in srgb, var(--rollout-theme-accent) 40%, rgb(55 65 81));
+  background-color: color-mix(in srgb, var(--rollout-theme-dark-surface) 28%, rgb(31 41 55));
 }
 
 .dark .environment-theme-card:hover {
-	border-color: color-mix(in srgb, var(--rollout-theme-accent) 55%, rgb(55 65 81));
+  border-color: color-mix(in srgb, var(--rollout-theme-accent) 55%, rgb(55 65 81));
 }
 
 .dark {
-	* {
-		scrollbar-color: #4b5563 #1f2937;
-	}
+  * {
+    scrollbar-color: #4b5563 #1f2937;
+  }
 
-	::-webkit-scrollbar-track {
-		@apply bg-gray-800;
-	}
+  ::-webkit-scrollbar-track {
+    @apply bg-gray-800;
+  }
 
-	::-webkit-scrollbar-thumb {
-		@apply bg-gray-600;
-	}
+  ::-webkit-scrollbar-thumb {
+    @apply bg-gray-600;
+  }
 
-	::-webkit-scrollbar-thumb:hover {
-		@apply bg-gray-500;
-	}
+  ::-webkit-scrollbar-thumb:hover {
+    @apply bg-gray-500;
+  }
 }
 
 /* Animated gradient border */
 @property --border-angle {
-	inherits: false;
-	initial-value: 0deg;
-	syntax: '<angle>';
+  inherits: false;
+  initial-value: 0deg;
+  syntax: '<angle>';
 }
 
 @keyframes border {
-	to {
-		--border-angle: 360deg;
-	}
+  to {
+    --border-angle: 360deg;
+  }
 }
 
 .animate-border {
-	animation: border 4s linear infinite;
+  animation: border 4s linear infinite;
 }
 
 /* Neon border animation */
 @property --angle {
-	syntax: '<angle>';
-	initial-value: 0deg;
-	inherits: false;
+  syntax: "<angle>";
+  initial-value: 0deg;
+  inherits: false;
 }
 
 @keyframes gradient-rotate {
-	from {
-		--angle: 0deg;
-	}
+  from {
+    --angle: 0deg;
+  }
 
-	to {
-		--angle: 360deg;
-	}
+  to {
+    --angle: 360deg;
+  }
 }
 
 .animate-gradient-rotate {
-	animation: gradient-rotate 3s linear infinite;
+  animation: gradient-rotate 3s linear infinite;
 }

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -1,4 +1,4 @@
-@import "tailwindcss";
+@import 'tailwindcss';
 
 @plugin 'flowbite/plugin';
 
@@ -8,105 +8,158 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 @theme {
-  --color-primary-50: #fff5f2;
-  --color-primary-100: #fff1ee;
-  --color-primary-200: #ffe4de;
-  --color-primary-300: #ffd5cc;
-  --color-primary-400: #ffbcad;
-  --color-primary-500: #fe795d;
-  --color-primary-600: #ef562f;
-  --color-primary-700: #eb4f27;
-  --color-primary-800: #cc4522;
-  --color-primary-900: #a5371b;
+	--color-primary-50: #fff5f2;
+	--color-primary-100: #fff1ee;
+	--color-primary-200: #ffe4de;
+	--color-primary-300: #ffd5cc;
+	--color-primary-400: #ffbcad;
+	--color-primary-500: #fe795d;
+	--color-primary-600: #ef562f;
+	--color-primary-700: #eb4f27;
+	--color-primary-800: #cc4522;
+	--color-primary-900: #a5371b;
 
-  --color-secondary-50: #f0f9ff;
-  --color-secondary-100: #e0f2fe;
-  --color-secondary-200: #bae6fd;
-  --color-secondary-300: #7dd3fc;
-  --color-secondary-400: #38bdf8;
-  --color-secondary-500: #0ea5e9;
-  --color-secondary-600: #0284c7;
-  --color-secondary-700: #0369a1;
-  --color-secondary-800: #075985;
-  --color-secondary-900: #0c4a6e;
+	--color-secondary-50: #f0f9ff;
+	--color-secondary-100: #e0f2fe;
+	--color-secondary-200: #bae6fd;
+	--color-secondary-300: #7dd3fc;
+	--color-secondary-400: #38bdf8;
+	--color-secondary-500: #0ea5e9;
+	--color-secondary-600: #0284c7;
+	--color-secondary-700: #0369a1;
+	--color-secondary-800: #075985;
+	--color-secondary-900: #0c4a6e;
 
-  --font-montserrat: "Montserrat", sans-serif;
+	--font-montserrat: 'Montserrat', sans-serif;
 }
 
 @source "../node_modules/flowbite-svelte/dist";
 @source "../node_modules/flowbite-svelte-icons/dist";
 
 @layer base {
+	button,
+	[role='button'] {
+		cursor: pointer;
+	}
 
-  button,
-  [role="button"] {
-    cursor: pointer;
-  }
-
-  /* disable chrome cancel button */
-  input[type="search"]::-webkit-search-cancel-button {
-    display: none;
-  }
-
+	/* disable chrome cancel button */
+	input[type='search']::-webkit-search-cancel-button {
+		display: none;
+	}
 }
 
 /* prevent iOS Safari from zooming on input focus — must be unlayered to beat Tailwind utilities */
-input, select, textarea {
-  font-size: max(16px, 1em);
+input,
+select,
+textarea {
+	font-size: max(16px, 1em);
+}
+
+.environment-theme-scope {
+	--rollout-theme-accent: #2563eb;
+	--rollout-theme-text: #1d4ed8;
+	--rollout-theme-border: #bfdbfe;
+	--rollout-theme-surface: #eff6ff;
+	--rollout-theme-dark-surface: #172554;
+	--rollout-theme-dark-text: #93c5fd;
+}
+
+.environment-theme-accent {
+	background-color: var(--rollout-theme-accent);
+}
+
+.environment-theme-text {
+	color: var(--rollout-theme-text);
+}
+
+.environment-theme-border {
+	border-color: var(--rollout-theme-border);
+}
+
+.environment-theme-surface {
+	background-color: var(--rollout-theme-surface);
+	color: var(--rollout-theme-text);
+}
+
+.environment-theme-card {
+	border-color: var(--rollout-theme-border);
+	background-color: color-mix(in srgb, var(--rollout-theme-surface) 65%, white);
+}
+
+.environment-theme-card:hover {
+	border-color: color-mix(in srgb, var(--rollout-theme-accent) 55%, white);
+}
+
+.dark .environment-theme-text {
+	color: var(--rollout-theme-dark-text);
+}
+
+.dark .environment-theme-surface {
+	background-color: color-mix(in srgb, var(--rollout-theme-dark-surface) 45%, transparent);
+	color: var(--rollout-theme-dark-text);
+}
+
+.dark .environment-theme-card {
+	border-color: color-mix(in srgb, var(--rollout-theme-accent) 40%, rgb(55 65 81));
+	background-color: color-mix(in srgb, var(--rollout-theme-dark-surface) 28%, rgb(31 41 55));
+}
+
+.dark .environment-theme-card:hover {
+	border-color: color-mix(in srgb, var(--rollout-theme-accent) 55%, rgb(55 65 81));
 }
 
 .dark {
-  * {
-    scrollbar-color: #4b5563 #1f2937;
-  }
+	* {
+		scrollbar-color: #4b5563 #1f2937;
+	}
 
-  ::-webkit-scrollbar-track {
-    @apply bg-gray-800;
-  }
+	::-webkit-scrollbar-track {
+		@apply bg-gray-800;
+	}
 
-  ::-webkit-scrollbar-thumb {
-    @apply bg-gray-600;
-  }
+	::-webkit-scrollbar-thumb {
+		@apply bg-gray-600;
+	}
 
-  ::-webkit-scrollbar-thumb:hover {
-    @apply bg-gray-500;
-  }
+	::-webkit-scrollbar-thumb:hover {
+		@apply bg-gray-500;
+	}
 }
 
 /* Animated gradient border */
 @property --border-angle {
-  inherits: false;
-  initial-value: 0deg;
-  syntax: '<angle>';
+	inherits: false;
+	initial-value: 0deg;
+	syntax: '<angle>';
 }
 
 @keyframes border {
-  to {
-    --border-angle: 360deg;
-  }
+	to {
+		--border-angle: 360deg;
+	}
 }
 
 .animate-border {
-  animation: border 4s linear infinite;
+	animation: border 4s linear infinite;
 }
 
 /* Neon border animation */
 @property --angle {
-  syntax: "<angle>";
-  initial-value: 0deg;
-  inherits: false;
+	syntax: '<angle>';
+	initial-value: 0deg;
+	inherits: false;
 }
 
 @keyframes gradient-rotate {
-  from {
-    --angle: 0deg;
-  }
+	from {
+		--angle: 0deg;
+	}
 
-  to {
-    --angle: 360deg;
-  }
+	to {
+		--angle: 360deg;
+	}
 }
 
 .animate-gradient-rotate {
-  animation: gradient-rotate 3s linear infinite;
+	animation: gradient-rotate 3s linear infinite;
 }

--- a/frontend/src/lib/CLAUDE.md
+++ b/frontend/src/lib/CLAUDE.md
@@ -16,3 +16,7 @@
 | #1043 | 7:09 PM | ✅ | Mobile Filter Bar Layout Improvement | ~405 |
 | #1034 | 1:08 PM | 🔄 | Rollout-Dashboard List View Redesign | ~595 |
 </claude-mem-context>
+
+## Rollout list visual treatment
+
+- Avoid environment theming that thickens or recolors rollout list card borders; status coloring owns that visual channel.

--- a/frontend/src/lib/Navbar.svelte
+++ b/frontend/src/lib/Navbar.svelte
@@ -80,7 +80,7 @@
 	style={rolloutThemeStyle}
 >
 	{#if rolloutTheme}
-		<div class="environment-theme-accent h-1 w-full" aria-hidden="true"></div>
+		<div class="h-1 w-full environment-theme-accent" aria-hidden="true"></div>
 	{/if}
 	<div class="flex w-full flex-wrap items-center justify-between px-2 py-2 sm:px-4">
 		<div class="flex min-w-0 flex-1 items-center gap-2 sm:gap-4">
@@ -92,22 +92,18 @@
 						{@html currentTheme === 'dark' ? LogoDark : LogoLight}
 					</div>
 				</div>
-				<span
-					class="font-montserrat hidden text-xl font-thin text-gray-600 sm:inline dark:text-gray-400"
+				<span class="hidden font-montserrat text-xl font-thin text-gray-600 dark:text-gray-400 sm:inline"
 					>kuberik</span
 				>
-				<div class="hidden h-6 w-px bg-gray-300 sm:block dark:bg-gray-600"></div>
+				<div class="hidden h-6 w-px bg-gray-300 dark:bg-gray-600 sm:block"></div>
 				<div class="flex flex-col">
-					<span class="text-xl font-light sm:text-2xl dark:text-white">Rollouts</span>
+					<span class="text-xl font-light dark:text-white sm:text-2xl">Rollouts</span>
 				</div>
 			</a>
 			{#if isRolloutPage && rollout}
 				<!-- Ghost breadcrumb switcher trigger -->
 				<div class="flex min-w-0 items-center gap-1">
-					<span
-						class="text-xl font-light text-gray-300 select-none dark:text-gray-600"
-						aria-hidden="true">/</span
-					>
+					<span class="select-none text-xl font-light text-gray-300 dark:text-gray-600" aria-hidden="true">/</span>
 					<button
 						type="button"
 						onclick={() => (switcherOpen = true)}
@@ -115,29 +111,25 @@
 						aria-label="Switch rollout (⌘K)"
 					>
 						<span class="flex min-w-0 items-baseline gap-1.5">
-							<span class="hidden truncate text-sm text-gray-500 sm:inline dark:text-gray-400">
+							<span class="hidden truncate text-sm text-gray-500 dark:text-gray-400 sm:inline">
 								{rollout.metadata?.namespace}
 							</span>
-							<span class="hidden text-gray-300 sm:inline dark:text-gray-600">/</span>
+							<span class="hidden text-gray-300 dark:text-gray-600 sm:inline">/</span>
 							<span class="truncate text-sm font-semibold text-gray-900 dark:text-white">
 								{rollout.metadata?.name}
 							</span>
 							{#if rolloutTheme}
 								<span
-									class="environment-theme-surface hidden shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold tracking-wider uppercase sm:inline-flex"
+									class="environment-theme-surface hidden shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider sm:inline-flex"
 								>
 									{rolloutTheme.label}
 								</span>
 							{/if}
 						</span>
-						<kbd
-							class="hidden shrink-0 font-mono text-[10px] font-normal text-gray-300 transition-colors group-hover:text-gray-500 md:inline-block dark:text-gray-600 dark:group-hover:text-gray-400"
-						>
+						<kbd class="hidden shrink-0 font-mono text-[10px] font-normal text-gray-300 transition-colors group-hover:text-gray-500 dark:text-gray-600 dark:group-hover:text-gray-400 md:inline-block">
 							{isMac ? '⌘K' : 'Ctrl K'}
 						</kbd>
-						<ChevronSortOutline
-							class="h-3.5 w-3.5 shrink-0 text-gray-400 transition-colors group-hover:text-gray-600 dark:text-gray-500 dark:group-hover:text-gray-300"
-						/>
+						<ChevronSortOutline class="h-3.5 w-3.5 shrink-0 text-gray-400 transition-colors group-hover:text-gray-600 dark:text-gray-500 dark:group-hover:text-gray-300" />
 					</button>
 				</div>
 			{/if}
@@ -168,14 +160,10 @@
 				{/if}
 			{/if}
 			{#if import.meta.env.VITE_APP_VERSION}
-				<Badge
-					color="none"
-					class="hidden bg-gray-200 text-gray-600 sm:inline-flex dark:bg-gray-700 dark:text-gray-400"
-					>{import.meta.env.VITE_APP_VERSION}</Badge
-				>
+				<Badge color="none" class="hidden bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-400 sm:inline-flex">{import.meta.env.VITE_APP_VERSION}</Badge>
 			{/if}
 			<button
-				class="rounded-lg bg-gray-100 p-1.5 text-gray-800 transition-colors hover:bg-gray-200 sm:p-2 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600"
+				class="rounded-lg bg-gray-100 p-1.5 text-gray-800 transition-colors hover:bg-gray-200 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600 sm:p-2"
 				onclick={() => theme.toggle()}
 				aria-label="Toggle dark mode"
 			>

--- a/frontend/src/lib/Navbar.svelte
+++ b/frontend/src/lib/Navbar.svelte
@@ -82,7 +82,7 @@
 	style={rolloutThemeStyle}
 >
 	{#if rolloutTheme}
-		<div class="h-0.5 w-full environment-theme-accent" aria-hidden="true"></div>
+		<div class="h-1 w-full environment-theme-accent" aria-hidden="true"></div>
 	{/if}
 	<div class="flex w-full flex-wrap items-center justify-between px-2 py-2 sm:px-4">
 		<div class="flex min-w-0 flex-1 items-center gap-2 sm:gap-4">
@@ -121,11 +121,13 @@
 								{rollout.metadata?.name}
 							</span>
 							{#if rolloutTheme}
-								<span
-									class="environment-theme-badge hidden shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider sm:inline-flex"
+								<Badge
+									color="gray"
+									size="small"
+									class="environment-theme-badge hidden shrink-0 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider sm:inline-flex"
 								>
 									{rolloutTheme.label}
-								</span>
+								</Badge>
 							{/if}
 						</span>
 						<kbd class="hidden shrink-0 font-mono text-[10px] font-normal text-gray-300 transition-colors group-hover:text-gray-500 dark:text-gray-600 dark:group-hover:text-gray-400 md:inline-block">

--- a/frontend/src/lib/Navbar.svelte
+++ b/frontend/src/lib/Navbar.svelte
@@ -58,7 +58,9 @@
 
 	const rollout = $derived(rolloutQuery.data?.rollout as Rollout | null);
 	const allRollouts = $derived(allRolloutsQuery.data?.rollouts?.items || []);
-	const rolloutTheme = $derived(rollout ? getRolloutEnvironmentTheme(rollout) : null);
+	const rolloutTheme = $derived(
+		rollout ? getRolloutEnvironmentTheme(rollout, rolloutQuery.data?.environment) : null
+	);
 	const rolloutThemeStyle = $derived(
 		rolloutTheme ? getEnvironmentThemeStyle(rolloutTheme) : undefined
 	);
@@ -80,7 +82,7 @@
 	style={rolloutThemeStyle}
 >
 	{#if rolloutTheme}
-		<div class="h-1 w-full environment-theme-accent" aria-hidden="true"></div>
+		<div class="h-0.5 w-full environment-theme-accent" aria-hidden="true"></div>
 	{/if}
 	<div class="flex w-full flex-wrap items-center justify-between px-2 py-2 sm:px-4">
 		<div class="flex min-w-0 flex-1 items-center gap-2 sm:gap-4">
@@ -120,7 +122,7 @@
 							</span>
 							{#if rolloutTheme}
 								<span
-									class="environment-theme-surface hidden shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider sm:inline-flex"
+									class="environment-theme-badge hidden shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider sm:inline-flex"
 								>
 									{rolloutTheme.label}
 								</span>

--- a/frontend/src/lib/Navbar.svelte
+++ b/frontend/src/lib/Navbar.svelte
@@ -14,6 +14,7 @@
 	import { createQuery } from '@tanstack/svelte-query';
 	import { rolloutsListQueryOptions, rolloutQueryOptions } from '$lib/api/rollouts';
 	import RolloutSwitcher from '$lib/RolloutSwitcher.svelte';
+	import { getEnvironmentThemeStyle, getRolloutEnvironmentTheme } from '$lib/environment-theme';
 
 	let currentTheme = $state<'light' | 'dark'>('light');
 	let switcherOpen = $state(false);
@@ -57,6 +58,10 @@
 
 	const rollout = $derived(rolloutQuery.data?.rollout as Rollout | null);
 	const allRollouts = $derived(allRolloutsQuery.data?.rollouts?.items || []);
+	const rolloutTheme = $derived(rollout ? getRolloutEnvironmentTheme(rollout) : null);
+	const rolloutThemeStyle = $derived(
+		rolloutTheme ? getEnvironmentThemeStyle(rolloutTheme) : undefined
+	);
 
 	// Global ⌘K / Ctrl+K shortcut
 	function handleGlobalKeydown(e: KeyboardEvent) {
@@ -71,8 +76,12 @@
 <svelte:window onkeydown={handleGlobalKeydown} />
 
 <nav
-	class="sticky top-0 z-50 w-full border-b border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800"
+	class="environment-theme-scope sticky top-0 z-50 w-full border-b border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800"
+	style={rolloutThemeStyle}
 >
+	{#if rolloutTheme}
+		<div class="environment-theme-accent h-1 w-full" aria-hidden="true"></div>
+	{/if}
 	<div class="flex w-full flex-wrap items-center justify-between px-2 py-2 sm:px-4">
 		<div class="flex min-w-0 flex-1 items-center gap-2 sm:gap-4">
 			<a href="/" class="flex shrink-0 items-center space-x-2 sm:space-x-3 rtl:space-x-reverse">
@@ -83,18 +92,22 @@
 						{@html currentTheme === 'dark' ? LogoDark : LogoLight}
 					</div>
 				</div>
-				<span class="hidden font-montserrat text-xl font-thin text-gray-600 dark:text-gray-400 sm:inline"
+				<span
+					class="font-montserrat hidden text-xl font-thin text-gray-600 sm:inline dark:text-gray-400"
 					>kuberik</span
 				>
-				<div class="hidden h-6 w-px bg-gray-300 dark:bg-gray-600 sm:block"></div>
+				<div class="hidden h-6 w-px bg-gray-300 sm:block dark:bg-gray-600"></div>
 				<div class="flex flex-col">
-					<span class="text-xl font-light dark:text-white sm:text-2xl">Rollouts</span>
+					<span class="text-xl font-light sm:text-2xl dark:text-white">Rollouts</span>
 				</div>
 			</a>
 			{#if isRolloutPage && rollout}
 				<!-- Ghost breadcrumb switcher trigger -->
 				<div class="flex min-w-0 items-center gap-1">
-					<span class="select-none text-xl font-light text-gray-300 dark:text-gray-600" aria-hidden="true">/</span>
+					<span
+						class="text-xl font-light text-gray-300 select-none dark:text-gray-600"
+						aria-hidden="true">/</span
+					>
 					<button
 						type="button"
 						onclick={() => (switcherOpen = true)}
@@ -102,18 +115,29 @@
 						aria-label="Switch rollout (⌘K)"
 					>
 						<span class="flex min-w-0 items-baseline gap-1.5">
-							<span class="hidden truncate text-sm text-gray-500 dark:text-gray-400 sm:inline">
+							<span class="hidden truncate text-sm text-gray-500 sm:inline dark:text-gray-400">
 								{rollout.metadata?.namespace}
 							</span>
-							<span class="hidden text-gray-300 dark:text-gray-600 sm:inline">/</span>
+							<span class="hidden text-gray-300 sm:inline dark:text-gray-600">/</span>
 							<span class="truncate text-sm font-semibold text-gray-900 dark:text-white">
 								{rollout.metadata?.name}
 							</span>
+							{#if rolloutTheme}
+								<span
+									class="environment-theme-surface hidden shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold tracking-wider uppercase sm:inline-flex"
+								>
+									{rolloutTheme.label}
+								</span>
+							{/if}
 						</span>
-						<kbd class="hidden shrink-0 font-mono text-[10px] font-normal text-gray-300 transition-colors group-hover:text-gray-500 dark:text-gray-600 dark:group-hover:text-gray-400 md:inline-block">
+						<kbd
+							class="hidden shrink-0 font-mono text-[10px] font-normal text-gray-300 transition-colors group-hover:text-gray-500 md:inline-block dark:text-gray-600 dark:group-hover:text-gray-400"
+						>
 							{isMac ? '⌘K' : 'Ctrl K'}
 						</kbd>
-						<ChevronSortOutline class="h-3.5 w-3.5 shrink-0 text-gray-400 transition-colors group-hover:text-gray-600 dark:text-gray-500 dark:group-hover:text-gray-300" />
+						<ChevronSortOutline
+							class="h-3.5 w-3.5 shrink-0 text-gray-400 transition-colors group-hover:text-gray-600 dark:text-gray-500 dark:group-hover:text-gray-300"
+						/>
 					</button>
 				</div>
 			{/if}
@@ -144,10 +168,14 @@
 				{/if}
 			{/if}
 			{#if import.meta.env.VITE_APP_VERSION}
-				<Badge color="none" class="hidden bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-400 sm:inline-flex">{import.meta.env.VITE_APP_VERSION}</Badge>
+				<Badge
+					color="none"
+					class="hidden bg-gray-200 text-gray-600 sm:inline-flex dark:bg-gray-700 dark:text-gray-400"
+					>{import.meta.env.VITE_APP_VERSION}</Badge
+				>
 			{/if}
 			<button
-				class="rounded-lg bg-gray-100 p-1.5 text-gray-800 transition-colors hover:bg-gray-200 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600 sm:p-2"
+				class="rounded-lg bg-gray-100 p-1.5 text-gray-800 transition-colors hover:bg-gray-200 sm:p-2 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600"
 				onclick={() => theme.toggle()}
 				aria-label="Toggle dark mode"
 			>

--- a/frontend/src/lib/RolloutSwitcher.svelte
+++ b/frontend/src/lib/RolloutSwitcher.svelte
@@ -6,6 +6,7 @@
 	import type { Rollout } from '../types';
 	import { getRolloutStatus } from '$lib/utils';
 	import { SearchOutline } from 'flowbite-svelte-icons';
+	import { getEnvironmentThemeStyle, getRolloutEnvironmentTheme } from '$lib/environment-theme';
 
 	let {
 		open = $bindable(false),
@@ -67,8 +68,7 @@
 			query = '';
 			await tick();
 			const idx = filtered.findIndex(
-				(r) =>
-					r.metadata?.name === currentName && r.metadata?.namespace === currentNamespace
+				(r) => r.metadata?.name === currentName && r.metadata?.namespace === currentNamespace
 			);
 			selectedIndex = idx >= 0 ? idx : 0;
 			searchInput?.focus();
@@ -117,17 +117,24 @@
 <svelte:window onkeydown={handleKeydown} />
 
 {#if open}
-	<div class="fixed inset-0 z-[100] flex items-start justify-center pt-[12vh]" role="dialog" aria-modal="true" aria-label="Switch rollout">
+	<div
+		class="fixed inset-0 z-[100] flex items-start justify-center pt-[12vh]"
+		role="dialog"
+		aria-modal="true"
+		aria-label="Switch rollout"
+	>
 		<!-- Backdrop -->
 		<button
 			type="button"
 			aria-label="Close"
-			class="fixed inset-0 bg-gray-900/60 backdrop-blur-sm backdrop-enter"
+			class="backdrop-enter fixed inset-0 bg-gray-900/60 backdrop-blur-sm"
 			onclick={() => (open = false)}
 		></button>
 
 		<!-- Palette -->
-		<div class="relative z-10 mx-4 w-full max-w-xl overflow-hidden rounded-xl bg-white shadow-2xl ring-1 ring-gray-200 palette-enter dark:bg-gray-800 dark:ring-gray-700">
+		<div
+			class="palette-enter relative z-10 mx-4 w-full max-w-xl overflow-hidden rounded-xl bg-white shadow-2xl ring-1 ring-gray-200 dark:bg-gray-800 dark:ring-gray-700"
+		>
 			<!-- Search -->
 			<div class="flex items-center gap-3 border-b border-gray-200 px-4 py-3 dark:border-gray-700">
 				<SearchOutline class="h-4 w-4 shrink-0 text-gray-400" />
@@ -139,9 +146,12 @@
 					placeholder="Search rollouts..."
 					autocomplete="off"
 					spellcheck="false"
-					class="flex-1 border-0 bg-transparent p-0 text-sm text-gray-900 placeholder-gray-400 outline-none focus:outline-none focus:ring-0 dark:text-white"
+					class="flex-1 border-0 bg-transparent p-0 text-sm text-gray-900 placeholder-gray-400 outline-none focus:ring-0 focus:outline-none dark:text-white"
 				/>
-				<kbd class="hidden shrink-0 rounded border border-gray-300 bg-gray-50 px-1.5 py-0.5 font-mono text-[10px] font-medium text-gray-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-400 sm:inline-block">ESC</kbd>
+				<kbd
+					class="hidden shrink-0 rounded border border-gray-300 bg-gray-50 px-1.5 py-0.5 font-mono text-[10px] font-medium text-gray-500 sm:inline-block dark:border-gray-600 dark:bg-gray-700 dark:text-gray-400"
+					>ESC</kbd
+				>
 			</div>
 
 			<!-- List -->
@@ -152,46 +162,78 @@
 					</div>
 				{:else if filtered.length === 0}
 					<div class="py-12 text-center text-sm text-gray-500 dark:text-gray-400">
-						No rollouts match <span class="font-medium text-gray-700 dark:text-gray-300">"{query}"</span>
+						No rollouts match <span class="font-medium text-gray-700 dark:text-gray-300"
+							>"{query}"</span
+						>
 					</div>
 				{:else}
 					{#each grouped as group (group.ns)}
-						<div class="px-3 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
+						<div
+							class="px-3 pt-2 pb-1 text-[10px] font-semibold tracking-wider text-gray-400 uppercase dark:text-gray-500"
+						>
 							{group.ns}
 						</div>
 						{#each group.items as item (`${group.ns}/${item.rollout.metadata?.name}`)}
 							{@const r = item.rollout}
 							{@const idx = item.idx}
-							{@const isCurrent = r.metadata?.name === currentName && r.metadata?.namespace === currentNamespace}
+							{@const isCurrent =
+								r.metadata?.name === currentName && r.metadata?.namespace === currentNamespace}
 							{@const status = getRolloutStatus(r)}
 							{@const isActive = idx === selectedIndex}
+							{@const rolloutTheme = getRolloutEnvironmentTheme(r)}
 							<button
 								type="button"
 								data-idx={idx}
+								style={rolloutTheme ? getEnvironmentThemeStyle(rolloutTheme) : undefined}
 								class="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left transition-colors {isActive
-									? 'bg-blue-50 dark:bg-blue-900/40'
+									? rolloutTheme
+										? 'environment-theme-scope environment-theme-surface'
+										: 'bg-blue-50 dark:bg-blue-900/40'
 									: 'hover:bg-gray-50 dark:hover:bg-gray-700/50'}"
 								onclick={() => selectRollout(r)}
 								onmouseenter={() => (selectedIndex = idx)}
 							>
 								<span class="relative flex h-2.5 w-2.5 shrink-0 items-center justify-center">
 									{#if status.color === 'yellow'}
-										<span class="absolute inline-flex h-full w-full animate-ping rounded-full bg-yellow-400 opacity-60"></span>
+										<span
+											class="absolute inline-flex h-full w-full animate-ping rounded-full bg-yellow-400 opacity-60"
+										></span>
 									{/if}
-									<span class="h-2 w-2 rounded-full {status.color === 'green' ? 'bg-green-500' : status.color === 'red' ? 'bg-red-500' : 'bg-yellow-500'}"></span>
+									<span
+										class="h-2 w-2 rounded-full {status.color === 'green'
+											? 'bg-green-500'
+											: status.color === 'red'
+												? 'bg-red-500'
+												: 'bg-yellow-500'}"
+									></span>
 								</span>
 								<div class="flex min-w-0 flex-1 flex-col">
-									<span class="truncate text-sm font-medium {isActive ? 'text-blue-700 dark:text-blue-200' : 'text-gray-900 dark:text-white'}">
+									<span
+										class="truncate text-sm font-medium {isActive
+											? rolloutTheme
+												? 'environment-theme-text'
+												: 'text-blue-700 dark:text-blue-200'
+											: 'text-gray-900 dark:text-white'}"
+									>
 										{r.metadata?.name}
 									</span>
-									{#if r.status?.title}
-										<span class="truncate text-xs text-gray-500 dark:text-gray-400">
-											{r.status.title}
+									{#if rolloutTheme || r.status?.title}
+										<span class="flex min-w-0 items-center gap-1.5">
+											{#if rolloutTheme}
+												<span class="environment-theme-accent h-1.5 w-1.5 shrink-0 rounded-full"
+												></span>
+											{/if}
+											<span class="truncate text-xs text-gray-500 dark:text-gray-400">
+												{rolloutTheme?.label || r.status?.title}
+											</span>
 										</span>
 									{/if}
 								</div>
 								{#if isCurrent}
-									<span class="shrink-0 rounded bg-blue-100 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-blue-700 dark:bg-blue-900/60 dark:text-blue-300">Current</span>
+									<span
+										class="shrink-0 rounded bg-blue-100 px-1.5 py-0.5 text-[9px] font-semibold tracking-wider text-blue-700 uppercase dark:bg-blue-900/60 dark:text-blue-300"
+										>Current</span
+									>
 								{/if}
 							</button>
 						{/each}
@@ -200,15 +242,26 @@
 			</div>
 
 			<!-- Footer -->
-			<div class="flex items-center justify-between border-t border-gray-200 bg-gray-50 px-4 py-2 text-[11px] text-gray-500 dark:border-gray-700 dark:bg-gray-800/50 dark:text-gray-400">
+			<div
+				class="flex items-center justify-between border-t border-gray-200 bg-gray-50 px-4 py-2 text-[11px] text-gray-500 dark:border-gray-700 dark:bg-gray-800/50 dark:text-gray-400"
+			>
 				<div class="flex items-center gap-3">
 					<span class="flex items-center gap-1">
-						<kbd class="rounded border border-gray-300 bg-white px-1 py-0.5 font-mono text-[10px] font-medium dark:border-gray-600 dark:bg-gray-700">↑</kbd>
-						<kbd class="rounded border border-gray-300 bg-white px-1 py-0.5 font-mono text-[10px] font-medium dark:border-gray-600 dark:bg-gray-700">↓</kbd>
+						<kbd
+							class="rounded border border-gray-300 bg-white px-1 py-0.5 font-mono text-[10px] font-medium dark:border-gray-600 dark:bg-gray-700"
+							>↑</kbd
+						>
+						<kbd
+							class="rounded border border-gray-300 bg-white px-1 py-0.5 font-mono text-[10px] font-medium dark:border-gray-600 dark:bg-gray-700"
+							>↓</kbd
+						>
 						<span>navigate</span>
 					</span>
 					<span class="flex items-center gap-1">
-						<kbd class="rounded border border-gray-300 bg-white px-1 py-0.5 font-mono text-[10px] font-medium dark:border-gray-600 dark:bg-gray-700">↵</kbd>
+						<kbd
+							class="rounded border border-gray-300 bg-white px-1 py-0.5 font-mono text-[10px] font-medium dark:border-gray-600 dark:bg-gray-700"
+							>↵</kbd
+						>
 						<span>select</span>
 					</span>
 				</div>

--- a/frontend/src/lib/RolloutSwitcher.svelte
+++ b/frontend/src/lib/RolloutSwitcher.svelte
@@ -5,6 +5,7 @@
 	import { tick } from 'svelte';
 	import type { Rollout } from '../types';
 	import { getRolloutStatus } from '$lib/utils';
+	import { Badge } from 'flowbite-svelte';
 	import { SearchOutline } from 'flowbite-svelte-icons';
 	import { getEnvironmentThemeStyle, getRolloutEnvironmentTheme } from '$lib/environment-theme';
 
@@ -170,7 +171,11 @@
 							<button
 								type="button"
 								data-idx={idx}
-								class="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left transition-colors {isActive
+								aria-current={isCurrent ? 'page' : undefined}
+								title={isCurrent ? 'Currently open rollout' : undefined}
+								class="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left transition-colors {isCurrent
+									? 'ring-1 ring-inset ring-blue-200 dark:ring-blue-800/70'
+									: ''} {isActive
 									? 'bg-blue-50 dark:bg-blue-900/40'
 									: 'hover:bg-gray-50 dark:hover:bg-gray-700/50'}"
 								onclick={() => selectRollout(r)}
@@ -197,15 +202,14 @@
 									{/if}
 								</div>
 								{#if rolloutTheme}
-									<span
+									<Badge
+										color="gray"
+										size="small"
 										style={getEnvironmentThemeStyle(rolloutTheme)}
-										class="environment-theme-scope environment-theme-badge shrink-0 rounded-full px-2 py-0.5 text-[9px] font-semibold uppercase tracking-wider"
+										class="environment-theme-scope environment-theme-badge shrink-0 px-2 py-0.5 text-[9px] font-semibold uppercase tracking-wider"
 									>
 										{rolloutTheme.label}
-									</span>
-								{/if}
-								{#if isCurrent}
-									<span class="shrink-0 rounded bg-blue-100 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-blue-700 dark:bg-blue-900/60 dark:text-blue-300">Current</span>
+									</Badge>
 								{/if}
 							</button>
 						{/each}

--- a/frontend/src/lib/RolloutSwitcher.svelte
+++ b/frontend/src/lib/RolloutSwitcher.svelte
@@ -173,14 +173,18 @@
 								data-idx={idx}
 								aria-current={isCurrent ? 'page' : undefined}
 								title={isCurrent ? 'Currently open rollout' : undefined}
-								class="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left transition-colors {isCurrent
-									? 'ring-1 ring-inset ring-blue-200 dark:ring-blue-800/70'
-									: ''} {isActive
+								class="relative flex w-full items-center gap-3 overflow-hidden rounded-lg px-3 py-2 text-left transition-colors {isActive
 									? 'bg-blue-50 dark:bg-blue-900/40'
 									: 'hover:bg-gray-50 dark:hover:bg-gray-700/50'}"
 								onclick={() => selectRollout(r)}
 								onmouseenter={() => (selectedIndex = idx)}
 							>
+								{#if isCurrent}
+									<span
+										class="absolute top-1.5 bottom-1.5 left-0 w-0.5 rounded-r-full bg-blue-500 dark:bg-blue-400"
+										aria-hidden="true"
+									></span>
+								{/if}
 								<span class="relative flex h-2.5 w-2.5 shrink-0 items-center justify-center">
 									{#if status.color === 'yellow'}
 										<span class="absolute inline-flex h-full w-full animate-ping rounded-full bg-yellow-400 opacity-60"></span>

--- a/frontend/src/lib/RolloutSwitcher.svelte
+++ b/frontend/src/lib/RolloutSwitcher.svelte
@@ -170,11 +170,8 @@
 							<button
 								type="button"
 								data-idx={idx}
-								style={rolloutTheme ? getEnvironmentThemeStyle(rolloutTheme) : undefined}
 								class="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left transition-colors {isActive
-									? rolloutTheme
-										? 'environment-theme-scope environment-theme-surface'
-										: 'bg-blue-50 dark:bg-blue-900/40'
+									? 'bg-blue-50 dark:bg-blue-900/40'
 									: 'hover:bg-gray-50 dark:hover:bg-gray-700/50'}"
 								onclick={() => selectRollout(r)}
 								onmouseenter={() => (selectedIndex = idx)}
@@ -188,24 +185,25 @@
 								<div class="flex min-w-0 flex-1 flex-col">
 									<span
 										class="truncate text-sm font-medium {isActive
-											? rolloutTheme
-												? 'environment-theme-text'
-												: 'text-blue-700 dark:text-blue-200'
+											? 'text-blue-700 dark:text-blue-200'
 											: 'text-gray-900 dark:text-white'}"
 									>
 										{r.metadata?.name}
 									</span>
-									{#if rolloutTheme || r.status?.title}
-										<span class="flex min-w-0 items-center gap-1.5">
-											{#if rolloutTheme}
-												<span class="h-1.5 w-1.5 shrink-0 rounded-full environment-theme-accent"></span>
-											{/if}
-											<span class="truncate text-xs text-gray-500 dark:text-gray-400">
-												{rolloutTheme?.label || r.status?.title}
-											</span>
+									{#if r.status?.title}
+										<span class="truncate text-xs text-gray-500 dark:text-gray-400">
+											{r.status.title}
 										</span>
 									{/if}
 								</div>
+								{#if rolloutTheme}
+									<span
+										style={getEnvironmentThemeStyle(rolloutTheme)}
+										class="environment-theme-scope environment-theme-badge shrink-0 rounded-full px-2 py-0.5 text-[9px] font-semibold uppercase tracking-wider"
+									>
+										{rolloutTheme.label}
+									</span>
+								{/if}
 								{#if isCurrent}
 									<span class="shrink-0 rounded bg-blue-100 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-blue-700 dark:bg-blue-900/60 dark:text-blue-300">Current</span>
 								{/if}

--- a/frontend/src/lib/RolloutSwitcher.svelte
+++ b/frontend/src/lib/RolloutSwitcher.svelte
@@ -68,7 +68,8 @@
 			query = '';
 			await tick();
 			const idx = filtered.findIndex(
-				(r) => r.metadata?.name === currentName && r.metadata?.namespace === currentNamespace
+				(r) =>
+					r.metadata?.name === currentName && r.metadata?.namespace === currentNamespace
 			);
 			selectedIndex = idx >= 0 ? idx : 0;
 			searchInput?.focus();
@@ -117,24 +118,17 @@
 <svelte:window onkeydown={handleKeydown} />
 
 {#if open}
-	<div
-		class="fixed inset-0 z-[100] flex items-start justify-center pt-[12vh]"
-		role="dialog"
-		aria-modal="true"
-		aria-label="Switch rollout"
-	>
+	<div class="fixed inset-0 z-[100] flex items-start justify-center pt-[12vh]" role="dialog" aria-modal="true" aria-label="Switch rollout">
 		<!-- Backdrop -->
 		<button
 			type="button"
 			aria-label="Close"
-			class="backdrop-enter fixed inset-0 bg-gray-900/60 backdrop-blur-sm"
+			class="fixed inset-0 bg-gray-900/60 backdrop-blur-sm backdrop-enter"
 			onclick={() => (open = false)}
 		></button>
 
 		<!-- Palette -->
-		<div
-			class="palette-enter relative z-10 mx-4 w-full max-w-xl overflow-hidden rounded-xl bg-white shadow-2xl ring-1 ring-gray-200 dark:bg-gray-800 dark:ring-gray-700"
-		>
+		<div class="relative z-10 mx-4 w-full max-w-xl overflow-hidden rounded-xl bg-white shadow-2xl ring-1 ring-gray-200 palette-enter dark:bg-gray-800 dark:ring-gray-700">
 			<!-- Search -->
 			<div class="flex items-center gap-3 border-b border-gray-200 px-4 py-3 dark:border-gray-700">
 				<SearchOutline class="h-4 w-4 shrink-0 text-gray-400" />
@@ -146,12 +140,9 @@
 					placeholder="Search rollouts..."
 					autocomplete="off"
 					spellcheck="false"
-					class="flex-1 border-0 bg-transparent p-0 text-sm text-gray-900 placeholder-gray-400 outline-none focus:ring-0 focus:outline-none dark:text-white"
+					class="flex-1 border-0 bg-transparent p-0 text-sm text-gray-900 placeholder-gray-400 outline-none focus:outline-none focus:ring-0 dark:text-white"
 				/>
-				<kbd
-					class="hidden shrink-0 rounded border border-gray-300 bg-gray-50 px-1.5 py-0.5 font-mono text-[10px] font-medium text-gray-500 sm:inline-block dark:border-gray-600 dark:bg-gray-700 dark:text-gray-400"
-					>ESC</kbd
-				>
+				<kbd class="hidden shrink-0 rounded border border-gray-300 bg-gray-50 px-1.5 py-0.5 font-mono text-[10px] font-medium text-gray-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-400 sm:inline-block">ESC</kbd>
 			</div>
 
 			<!-- List -->
@@ -162,22 +153,17 @@
 					</div>
 				{:else if filtered.length === 0}
 					<div class="py-12 text-center text-sm text-gray-500 dark:text-gray-400">
-						No rollouts match <span class="font-medium text-gray-700 dark:text-gray-300"
-							>"{query}"</span
-						>
+						No rollouts match <span class="font-medium text-gray-700 dark:text-gray-300">"{query}"</span>
 					</div>
 				{:else}
 					{#each grouped as group (group.ns)}
-						<div
-							class="px-3 pt-2 pb-1 text-[10px] font-semibold tracking-wider text-gray-400 uppercase dark:text-gray-500"
-						>
+						<div class="px-3 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
 							{group.ns}
 						</div>
 						{#each group.items as item (`${group.ns}/${item.rollout.metadata?.name}`)}
 							{@const r = item.rollout}
 							{@const idx = item.idx}
-							{@const isCurrent =
-								r.metadata?.name === currentName && r.metadata?.namespace === currentNamespace}
+							{@const isCurrent = r.metadata?.name === currentName && r.metadata?.namespace === currentNamespace}
 							{@const status = getRolloutStatus(r)}
 							{@const isActive = idx === selectedIndex}
 							{@const rolloutTheme = getRolloutEnvironmentTheme(r)}
@@ -195,17 +181,9 @@
 							>
 								<span class="relative flex h-2.5 w-2.5 shrink-0 items-center justify-center">
 									{#if status.color === 'yellow'}
-										<span
-											class="absolute inline-flex h-full w-full animate-ping rounded-full bg-yellow-400 opacity-60"
-										></span>
+										<span class="absolute inline-flex h-full w-full animate-ping rounded-full bg-yellow-400 opacity-60"></span>
 									{/if}
-									<span
-										class="h-2 w-2 rounded-full {status.color === 'green'
-											? 'bg-green-500'
-											: status.color === 'red'
-												? 'bg-red-500'
-												: 'bg-yellow-500'}"
-									></span>
+									<span class="h-2 w-2 rounded-full {status.color === 'green' ? 'bg-green-500' : status.color === 'red' ? 'bg-red-500' : 'bg-yellow-500'}"></span>
 								</span>
 								<div class="flex min-w-0 flex-1 flex-col">
 									<span
@@ -220,8 +198,7 @@
 									{#if rolloutTheme || r.status?.title}
 										<span class="flex min-w-0 items-center gap-1.5">
 											{#if rolloutTheme}
-												<span class="environment-theme-accent h-1.5 w-1.5 shrink-0 rounded-full"
-												></span>
+												<span class="h-1.5 w-1.5 shrink-0 rounded-full environment-theme-accent"></span>
 											{/if}
 											<span class="truncate text-xs text-gray-500 dark:text-gray-400">
 												{rolloutTheme?.label || r.status?.title}
@@ -230,10 +207,7 @@
 									{/if}
 								</div>
 								{#if isCurrent}
-									<span
-										class="shrink-0 rounded bg-blue-100 px-1.5 py-0.5 text-[9px] font-semibold tracking-wider text-blue-700 uppercase dark:bg-blue-900/60 dark:text-blue-300"
-										>Current</span
-									>
+									<span class="shrink-0 rounded bg-blue-100 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-blue-700 dark:bg-blue-900/60 dark:text-blue-300">Current</span>
 								{/if}
 							</button>
 						{/each}
@@ -242,26 +216,15 @@
 			</div>
 
 			<!-- Footer -->
-			<div
-				class="flex items-center justify-between border-t border-gray-200 bg-gray-50 px-4 py-2 text-[11px] text-gray-500 dark:border-gray-700 dark:bg-gray-800/50 dark:text-gray-400"
-			>
+			<div class="flex items-center justify-between border-t border-gray-200 bg-gray-50 px-4 py-2 text-[11px] text-gray-500 dark:border-gray-700 dark:bg-gray-800/50 dark:text-gray-400">
 				<div class="flex items-center gap-3">
 					<span class="flex items-center gap-1">
-						<kbd
-							class="rounded border border-gray-300 bg-white px-1 py-0.5 font-mono text-[10px] font-medium dark:border-gray-600 dark:bg-gray-700"
-							>↑</kbd
-						>
-						<kbd
-							class="rounded border border-gray-300 bg-white px-1 py-0.5 font-mono text-[10px] font-medium dark:border-gray-600 dark:bg-gray-700"
-							>↓</kbd
-						>
+						<kbd class="rounded border border-gray-300 bg-white px-1 py-0.5 font-mono text-[10px] font-medium dark:border-gray-600 dark:bg-gray-700">↑</kbd>
+						<kbd class="rounded border border-gray-300 bg-white px-1 py-0.5 font-mono text-[10px] font-medium dark:border-gray-600 dark:bg-gray-700">↓</kbd>
 						<span>navigate</span>
 					</span>
 					<span class="flex items-center gap-1">
-						<kbd
-							class="rounded border border-gray-300 bg-white px-1 py-0.5 font-mono text-[10px] font-medium dark:border-gray-600 dark:bg-gray-700"
-							>↵</kbd
-						>
+						<kbd class="rounded border border-gray-300 bg-white px-1 py-0.5 font-mono text-[10px] font-medium dark:border-gray-600 dark:bg-gray-700">↵</kbd>
 						<span>select</span>
 					</span>
 				</div>

--- a/frontend/src/lib/Rollouts.svelte
+++ b/frontend/src/lib/Rollouts.svelte
@@ -2,7 +2,7 @@
 
 <script lang="ts">
 	import type { Rollout } from '../types';
-	import { Alert, Sidebar, SidebarGroup } from 'flowbite-svelte';
+	import { Alert, Badge, Sidebar, SidebarGroup } from 'flowbite-svelte';
 	import { SearchOutline, ArrowUpOutline, HeartSolid } from 'flowbite-svelte-icons';
 	import { getDisplayVersion } from '$lib/utils';
 	import { now } from '$lib/stores/time';
@@ -295,21 +295,22 @@
 									<a
 										href="/rollouts/{ns}/{name}"
 										style={rolloutTheme ? getEnvironmentThemeStyle(rolloutTheme) : undefined}
-										class="environment-theme-scope group relative flex flex-col overflow-hidden rounded-lg border transition-colors
+										class="environment-theme-scope group flex flex-col overflow-hidden rounded-lg border transition-colors
 											{status === 'Failed'
 												? 'border-red-200 bg-red-50 hover:border-red-300 dark:border-red-900/50 dark:bg-red-950/20 dark:hover:border-red-800'
 												: 'border-gray-200 bg-white hover:border-gray-300 dark:border-gray-700 dark:bg-gray-800 dark:hover:border-gray-600'}"
 									>
-										{#if rolloutTheme}
-											<div class="absolute inset-y-0 left-0 w-1 environment-theme-accent opacity-70" aria-hidden="true"></div>
-										{/if}
 										<div class="flex items-center gap-2 px-3 pt-2.5 pb-1.5">
 											<BakeStatusIcon bakeStatus={status} size="small" class="shrink-0" />
 											<span class="min-w-0 flex-1 truncate text-sm font-medium text-gray-900 dark:text-white">{name}</span>
 											{#if rolloutTheme}
-												<span class="environment-theme-badge shrink-0 rounded-full px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider">
+												<Badge
+													color="gray"
+													size="small"
+													class="environment-theme-badge shrink-0 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider"
+												>
 													{rolloutTheme.label}
-												</span>
+												</Badge>
 											{/if}
 											{#if latest?.timestamp}
 												<span class="shrink-0 text-xs tabular-nums text-gray-400 dark:text-gray-500">{compactTime(latest.timestamp, $now)}</span>

--- a/frontend/src/lib/Rollouts.svelte
+++ b/frontend/src/lib/Rollouts.svelte
@@ -9,37 +9,38 @@
 	import { createQuery } from '@tanstack/svelte-query';
 	import { rolloutsListQueryOptions } from '$lib/api/rollouts';
 	import BakeStatusIcon from '$lib/components/BakeStatusIcon.svelte';
+	import { getEnvironmentThemeStyle, getRolloutEnvironmentTheme } from '$lib/environment-theme';
 
 	const rolloutsQuery = createQuery(() =>
 		rolloutsListQueryOptions({ options: { staleTime: 30000 } })
 	);
 
 	const rollouts = $derived<Rollout[]>(rolloutsQuery.data?.rollouts?.items || []);
-	const loading  = $derived(rolloutsQuery.isLoading);
-	const error    = $derived(
+	const loading = $derived(rolloutsQuery.isLoading);
+	const error = $derived(
 		rolloutsQuery.isError ? (rolloutsQuery.error as Error).message || 'Unknown error' : null
 	);
 
-	let searchQuery     = $state('');
+	let searchQuery = $state('');
 	let namespaceFilter = $state('all');
-	let statusFilter    = $state('all');
+	let statusFilter = $state('all');
 
 	const uniqueNamespaces = $derived(
 		[...new Set(rollouts.map((r) => r.metadata?.namespace || 'default'))].sort()
 	);
 
 	const STATUS_TEXT: Record<string, string> = {
-		Succeeded:  'text-green-600 dark:text-green-400',
-		Failed:     'text-red-600 dark:text-red-400',
+		Succeeded: 'text-green-600 dark:text-green-400',
+		Failed: 'text-red-600 dark:text-red-400',
 		InProgress: 'text-yellow-600 dark:text-yellow-400',
-		Deploying:  'text-blue-600 dark:text-blue-400',
-		Cancelled:  'text-gray-500 dark:text-gray-400',
-		None:       'text-gray-400 dark:text-gray-500',
+		Deploying: 'text-blue-600 dark:text-blue-400',
+		Cancelled: 'text-gray-500 dark:text-gray-400',
+		None: 'text-gray-400 dark:text-gray-500'
 	};
 
 	const ACTIVE_LABEL: Record<string, string> = {
 		InProgress: 'Baking',
-		Deploying:  'Deploying',
+		Deploying: 'Deploying'
 	};
 
 	function getBakeStatus(r: Rollout): string {
@@ -48,8 +49,8 @@
 
 	function compactTime(timestamp: string, n: Date): string {
 		const s = Math.floor((n.getTime() - new Date(timestamp).getTime()) / 1000);
-		if (s < 60)    return `${s}s`;
-		if (s < 3600)  return `${Math.floor(s / 60)}m`;
+		if (s < 60) return `${s}s`;
+		if (s < 3600) return `${Math.floor(s / 60)}m`;
 		if (s < 86400) return `${Math.floor(s / 3600)}h`;
 		return `${Math.floor(s / 86400)}d`;
 	}
@@ -59,34 +60,45 @@
 		if (!m) return 0;
 		const v = parseInt(m[1]);
 		switch (m[2]) {
-			case 's': return v * 1000;
-			case 'm': return v * 60000;
-			case 'h': return v * 3600000;
-			case 'd': return v * 86400000;
-			default:  return 0;
+			case 's':
+				return v * 1000;
+			case 'm':
+				return v * 60000;
+			case 'h':
+				return v * 3600000;
+			case 'd':
+				return v * 86400000;
+			default:
+				return 0;
 		}
 	}
 
 	const STATUS_SORT: Record<string, number> = {
-		Failed: 0, InProgress: 1, Deploying: 2, None: 3, Cancelled: 4, Succeeded: 5
+		Failed: 0,
+		InProgress: 1,
+		Deploying: 2,
+		None: 3,
+		Cancelled: 4,
+		Succeeded: 5
 	};
 
 	const filteredRolloutsByNamespace = $derived.by(() => {
 		const filtered = rollouts
 			.filter((r) => {
-				const ns   = r.metadata?.namespace || 'default';
+				const ns = r.metadata?.namespace || 'default';
 				const name = r.metadata?.name || '';
-				const st   = getBakeStatus(r);
-				const matchesSearch = searchQuery === '' ||
+				const st = getBakeStatus(r);
+				const matchesSearch =
+					searchQuery === '' ||
 					name.toLowerCase().includes(searchQuery.toLowerCase()) ||
 					ns.toLowerCase().includes(searchQuery.toLowerCase());
 				const matchesNs = namespaceFilter === 'all' || ns === namespaceFilter;
 				const matchesStatus =
-					statusFilter === 'all'       ||
-					(statusFilter === 'active'    && (st === 'InProgress' || st === 'Deploying')) ||
-					(statusFilter === 'failed'    && st === 'Failed') ||
+					statusFilter === 'all' ||
+					(statusFilter === 'active' && (st === 'InProgress' || st === 'Deploying')) ||
+					(statusFilter === 'failed' && st === 'Failed') ||
 					(statusFilter === 'succeeded' && st === 'Succeeded') ||
-					(statusFilter === 'idle'      && st === 'None');
+					(statusFilter === 'idle' && st === 'None');
 				return matchesSearch && matchesNs && matchesStatus;
 			})
 			.sort((a, b) => {
@@ -100,7 +112,9 @@
 			if (!grouped[ns]) grouped[ns] = [];
 			grouped[ns].push(r);
 		});
-		return Object.keys(grouped).sort().map((ns) => ({ ns, rollouts: grouped[ns] }));
+		return Object.keys(grouped)
+			.sort()
+			.map((ns) => ({ ns, rollouts: grouped[ns] }));
 	});
 
 	const totalFiltered = $derived(
@@ -112,9 +126,9 @@
 		rollouts.forEach((r) => {
 			const st = getBakeStatus(r);
 			if (st === 'InProgress' || st === 'Deploying') c.active++;
-			else if (st === 'Failed')    c.failed++;
+			else if (st === 'Failed') c.failed++;
 			else if (st === 'Succeeded') c.succeeded++;
-			else if (st === 'None')      c.idle++;
+			else if (st === 'None') c.idle++;
 		});
 		return c;
 	});
@@ -130,86 +144,139 @@
 </script>
 
 <div class="flex h-full overflow-hidden">
-
 	<!-- ── Sidebar (desktop only) ── -->
 	<div class="hidden lg:block">
 		<Sidebar class="h-full border-r border-gray-200 dark:border-gray-700" position="static">
 			<div class="flex flex-col gap-4 px-3 py-4">
-
 				<!-- Search -->
 				<div class="relative">
-					<SearchOutline class="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-gray-400" />
+					<SearchOutline
+						class="pointer-events-none absolute top-1/2 left-2.5 h-3.5 w-3.5 -translate-y-1/2 text-gray-400"
+					/>
 					<input
 						type="search"
 						placeholder="Search…"
 						bind:value={searchQuery}
-						class="w-full rounded-md border border-gray-200 bg-gray-50 py-1.5 pl-8 pr-2 text-sm text-gray-900 placeholder-gray-400 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white"
+						class="w-full rounded-md border border-gray-200 bg-gray-50 py-1.5 pr-2 pl-8 text-sm text-gray-900 placeholder-gray-400 focus:border-transparent focus:ring-2 focus:ring-blue-500 focus:outline-none dark:border-gray-700 dark:bg-gray-800 dark:text-white"
 					/>
 				</div>
 
 				<!-- Status filter group -->
 				<SidebarGroup>
-					<p class="mb-1 px-3 text-[11px] font-semibold uppercase tracking-widest text-gray-400 dark:text-gray-500">Status</p>
-					<button onclick={() => (statusFilter = 'all')} class={sidebarItemClass(statusFilter === 'all')}>
+					<p
+						class="mb-1 px-3 text-[11px] font-semibold tracking-widest text-gray-400 uppercase dark:text-gray-500"
+					>
+						Status
+					</p>
+					<button
+						onclick={() => (statusFilter = 'all')}
+						class={sidebarItemClass(statusFilter === 'all')}
+					>
 						All
-						<span class="text-xs tabular-nums text-gray-400 dark:text-gray-500">{rollouts.length}</span>
+						<span class="text-xs text-gray-400 tabular-nums dark:text-gray-500"
+							>{rollouts.length}</span
+						>
 					</button>
-					<button onclick={() => (statusFilter = 'active')} class={sidebarItemClass(statusFilter === 'active')}>
-						<span class="flex items-center gap-2"><span class="h-2 w-2 rounded-full bg-yellow-400"></span>Active</span>
-						<span class="text-xs tabular-nums {statusCounts.active > 0 ? 'text-gray-500 dark:text-gray-400' : 'text-gray-300 dark:text-gray-600'}">{statusCounts.active}</span>
+					<button
+						onclick={() => (statusFilter = 'active')}
+						class={sidebarItemClass(statusFilter === 'active')}
+					>
+						<span class="flex items-center gap-2"
+							><span class="h-2 w-2 rounded-full bg-yellow-400"></span>Active</span
+						>
+						<span
+							class="text-xs tabular-nums {statusCounts.active > 0
+								? 'text-gray-500 dark:text-gray-400'
+								: 'text-gray-300 dark:text-gray-600'}">{statusCounts.active}</span
+						>
 					</button>
-					<button onclick={() => (statusFilter = 'failed')} class={sidebarItemClass(statusFilter === 'failed')}>
-						<span class="flex items-center gap-2"><span class="h-2 w-2 rounded-full bg-red-500"></span>Failed</span>
-						<span class="text-xs tabular-nums {statusCounts.failed > 0 ? 'font-semibold text-red-600 dark:text-red-400' : 'text-gray-300 dark:text-gray-600'}">{statusCounts.failed}</span>
+					<button
+						onclick={() => (statusFilter = 'failed')}
+						class={sidebarItemClass(statusFilter === 'failed')}
+					>
+						<span class="flex items-center gap-2"
+							><span class="h-2 w-2 rounded-full bg-red-500"></span>Failed</span
+						>
+						<span
+							class="text-xs tabular-nums {statusCounts.failed > 0
+								? 'font-semibold text-red-600 dark:text-red-400'
+								: 'text-gray-300 dark:text-gray-600'}">{statusCounts.failed}</span
+						>
 					</button>
-					<button onclick={() => (statusFilter = 'succeeded')} class={sidebarItemClass(statusFilter === 'succeeded')}>
-						<span class="flex items-center gap-2"><span class="h-2 w-2 rounded-full bg-green-500"></span>Succeeded</span>
-						<span class="text-xs tabular-nums text-gray-400 dark:text-gray-500">{statusCounts.succeeded}</span>
+					<button
+						onclick={() => (statusFilter = 'succeeded')}
+						class={sidebarItemClass(statusFilter === 'succeeded')}
+					>
+						<span class="flex items-center gap-2"
+							><span class="h-2 w-2 rounded-full bg-green-500"></span>Succeeded</span
+						>
+						<span class="text-xs text-gray-400 tabular-nums dark:text-gray-500"
+							>{statusCounts.succeeded}</span
+						>
 					</button>
-					<button onclick={() => (statusFilter = 'idle')} class={sidebarItemClass(statusFilter === 'idle')}>
-						<span class="flex items-center gap-2"><span class="h-2 w-2 rounded-full bg-gray-300 dark:bg-gray-600"></span>Idle</span>
-						<span class="text-xs tabular-nums text-gray-400 dark:text-gray-500">{statusCounts.idle}</span>
+					<button
+						onclick={() => (statusFilter = 'idle')}
+						class={sidebarItemClass(statusFilter === 'idle')}
+					>
+						<span class="flex items-center gap-2"
+							><span class="h-2 w-2 rounded-full bg-gray-300 dark:bg-gray-600"></span>Idle</span
+						>
+						<span class="text-xs text-gray-400 tabular-nums dark:text-gray-500"
+							>{statusCounts.idle}</span
+						>
 					</button>
 				</SidebarGroup>
 
 				<!-- Namespace filter group -->
 				{#if uniqueNamespaces.length > 1}
 					<SidebarGroup border>
-						<p class="mb-1 px-3 text-[11px] font-semibold uppercase tracking-widest text-gray-400 dark:text-gray-500">Namespace</p>
-						<button onclick={() => (namespaceFilter = 'all')} class={sidebarItemClass(namespaceFilter === 'all')}>All</button>
+						<p
+							class="mb-1 px-3 text-[11px] font-semibold tracking-widest text-gray-400 uppercase dark:text-gray-500"
+						>
+							Namespace
+						</p>
+						<button
+							onclick={() => (namespaceFilter = 'all')}
+							class={sidebarItemClass(namespaceFilter === 'all')}>All</button
+						>
 						{#each uniqueNamespaces as ns}
-							<button onclick={() => (namespaceFilter = ns)} class={sidebarItemClass(namespaceFilter === ns)}>
+							<button
+								onclick={() => (namespaceFilter = ns)}
+								class={sidebarItemClass(namespaceFilter === ns)}
+							>
 								<span class="truncate">{ns}</span>
 							</button>
 						{/each}
 					</SidebarGroup>
 				{/if}
-
 			</div>
 		</Sidebar>
 	</div>
 
 	<!-- ── Right side: mobile filter bar + cards ── -->
 	<div class="flex min-w-0 flex-1 flex-col overflow-hidden">
-
 		<!-- Mobile filter bar (hidden on desktop) -->
-		<div class="sticky top-0 z-10 border-b border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900 lg:hidden">
+		<div
+			class="sticky top-0 z-10 border-b border-gray-200 bg-white lg:hidden dark:border-gray-700 dark:bg-gray-900"
+		>
 			<div class="flex flex-col gap-2 px-3 py-2.5">
 				<!-- Search -->
 				<div class="relative">
-					<SearchOutline class="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-gray-400" />
+					<SearchOutline
+						class="pointer-events-none absolute top-1/2 left-2.5 h-3.5 w-3.5 -translate-y-1/2 text-gray-400"
+					/>
 					<input
 						type="search"
 						placeholder="Search rollouts…"
 						bind:value={searchQuery}
-						class="w-full rounded-md border border-gray-200 bg-gray-50 py-1.5 pl-8 pr-2 text-sm text-gray-900 placeholder-gray-400 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white"
+						class="w-full rounded-md border border-gray-200 bg-gray-50 py-1.5 pr-2 pl-8 text-sm text-gray-900 placeholder-gray-400 focus:border-transparent focus:ring-2 focus:ring-blue-500 focus:outline-none dark:border-gray-700 dark:bg-gray-800 dark:text-white"
 					/>
 				</div>
 				<!-- Selects row -->
 				<div class="flex gap-2">
 					<select
 						bind:value={statusFilter}
-						class="min-w-0 flex-1 rounded-md border border-gray-200 bg-gray-50 py-1.5 px-2 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300"
+						class="min-w-0 flex-1 rounded-md border border-gray-200 bg-gray-50 px-2 py-1.5 text-sm text-gray-700 focus:ring-2 focus:ring-blue-500 focus:outline-none dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300"
 					>
 						<option value="all">All statuses</option>
 						<option value="active">Active ({statusCounts.active})</option>
@@ -220,7 +287,7 @@
 					{#if uniqueNamespaces.length > 1}
 						<select
 							bind:value={namespaceFilter}
-							class="min-w-0 flex-1 rounded-md border border-gray-200 bg-gray-50 py-1.5 px-2 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300"
+							class="min-w-0 flex-1 rounded-md border border-gray-200 bg-gray-50 px-2 py-1.5 text-sm text-gray-700 focus:ring-2 focus:ring-blue-500 focus:outline-none dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300"
 						>
 							<option value="all">All namespaces</option>
 							{#each uniqueNamespaces as ns}
@@ -239,7 +306,9 @@
 					{#each Array(6) as _}
 						<div class="rounded-lg border border-gray-200 p-3 dark:border-gray-700">
 							<div class="flex items-center gap-2.5">
-								<div class="h-3 w-3 shrink-0 animate-pulse rounded-full bg-gray-200 dark:bg-gray-700"></div>
+								<div
+									class="h-3 w-3 shrink-0 animate-pulse rounded-full bg-gray-200 dark:bg-gray-700"
+								></div>
 								<div class="h-3 flex-1 animate-pulse rounded bg-gray-200 dark:bg-gray-700"></div>
 								<div class="h-3 w-8 animate-pulse rounded bg-gray-200 dark:bg-gray-700"></div>
 							</div>
@@ -257,9 +326,14 @@
 				<div class="py-16 text-center">
 					<p class="text-sm text-gray-500 dark:text-gray-400">No results.</p>
 					<button
-						onclick={() => { searchQuery = ''; namespaceFilter = 'all'; statusFilter = 'all'; }}
+						onclick={() => {
+							searchQuery = '';
+							namespaceFilter = 'all';
+							statusFilter = 'all';
+						}}
 						class="mt-2 text-xs text-blue-600 hover:underline dark:text-blue-400"
-					>Clear filters</button>
+						>Clear filters</button
+					>
 				</div>
 			{:else}
 				<div class="flex flex-col gap-4 p-3 sm:p-4">
@@ -267,24 +341,29 @@
 						<div>
 							{#if filteredRolloutsByNamespace.length > 1}
 								<div class="mb-2 flex items-center gap-2.5">
-									<span class="shrink-0 text-[11px] font-semibold uppercase tracking-widest text-gray-400 dark:text-gray-500">{group.ns}</span>
+									<span
+										class="shrink-0 text-[11px] font-semibold tracking-widest text-gray-400 uppercase dark:text-gray-500"
+										>{group.ns}</span
+									>
 									<div class="h-px flex-1 bg-gray-200 dark:bg-gray-700"></div>
 								</div>
 							{/if}
 
 							<div class="grid grid-cols-1 gap-2 sm:grid-cols-2 xl:grid-cols-3">
 								{#each group.rollouts as r}
-									{@const ns            = r.metadata?.namespace || 'default'}
-									{@const name          = r.metadata?.name || ''}
-									{@const latest        = r.status?.history?.[0]}
-									{@const status        = getBakeStatus(r)}
-									{@const versionLabel  = latest?.version ? getDisplayVersion(latest.version) : null}
-									{@const upgradeCount  = r.status?.releaseCandidates?.length || 0}
+									{@const ns = r.metadata?.namespace || 'default'}
+									{@const name = r.metadata?.name || ''}
+									{@const latest = r.status?.history?.[0]}
+									{@const status = getBakeStatus(r)}
+									{@const versionLabel = latest?.version ? getDisplayVersion(latest.version) : null}
+									{@const upgradeCount = r.status?.releaseCandidates?.length || 0}
 									{@const failedHCCount = latest?.failedHealthChecks?.length || 0}
-									{@const activeLabel   = ACTIVE_LABEL[status] ?? null}
-									{@const statusText    = STATUS_TEXT[status] ?? STATUS_TEXT['None']}
+									{@const activeLabel = ACTIVE_LABEL[status] ?? null}
+									{@const statusText = STATUS_TEXT[status] ?? STATUS_TEXT['None']}
+									{@const rolloutTheme = getRolloutEnvironmentTheme(r)}
 									{@const bakeProgressPct = (() => {
-										if (status !== 'InProgress' || !latest?.bakeStartTime || !r.spec?.bakeTime) return null;
+										if (status !== 'InProgress' || !latest?.bakeStartTime || !r.spec?.bakeTime)
+											return null;
 										const elapsed = $now.getTime() - new Date(latest.bakeStartTime).getTime();
 										const total = parseDuration(r.spec.bakeTime);
 										return total > 0 ? Math.min(100, Math.max(0, (elapsed / total) * 100)) : null;
@@ -292,40 +371,67 @@
 
 									<a
 										href="/rollouts/{ns}/{name}"
-										class="group flex flex-col overflow-hidden rounded-lg border transition-colors
+										style={rolloutTheme ? getEnvironmentThemeStyle(rolloutTheme) : undefined}
+										class="environment-theme-scope group flex flex-col overflow-hidden rounded-lg border transition-colors
 											{status === 'Failed'
-												? 'border-red-200 bg-red-50 hover:border-red-300 dark:border-red-900/50 dark:bg-red-950/20 dark:hover:border-red-800'
+											? 'border-red-200 bg-red-50 hover:border-red-300 dark:border-red-900/50 dark:bg-red-950/20 dark:hover:border-red-800'
+											: rolloutTheme
+												? 'environment-theme-card'
 												: 'border-gray-200 bg-white hover:border-gray-300 dark:border-gray-700 dark:bg-gray-800 dark:hover:border-gray-600'}"
 									>
+										{#if rolloutTheme}
+											<div class="environment-theme-accent h-1 w-full" aria-hidden="true"></div>
+										{/if}
 										<div class="flex items-center gap-2 px-3 pt-2.5 pb-1.5">
 											<BakeStatusIcon bakeStatus={status} size="small" class="shrink-0" />
-											<span class="min-w-0 flex-1 truncate text-sm font-medium text-gray-900 dark:text-white">{name}</span>
+											<span
+												class="min-w-0 flex-1 truncate text-sm font-medium text-gray-900 dark:text-white"
+												>{name}</span
+											>
+											{#if rolloutTheme}
+												<span
+													class="environment-theme-surface shrink-0 rounded-full px-1.5 py-0.5 text-[9px] font-semibold tracking-wider uppercase"
+												>
+													{rolloutTheme.label}
+												</span>
+											{/if}
 											{#if latest?.timestamp}
-												<span class="shrink-0 text-xs tabular-nums text-gray-400 dark:text-gray-500">{compactTime(latest.timestamp, $now)}</span>
+												<span class="shrink-0 text-xs text-gray-400 tabular-nums dark:text-gray-500"
+													>{compactTime(latest.timestamp, $now)}</span
+												>
 											{/if}
 										</div>
 										<div class="flex min-h-[1.75rem] items-center gap-1.5 px-3 pb-2.5 pl-7">
 											{#if versionLabel}
-												<span class="font-mono text-xs text-gray-400 dark:text-gray-500">{versionLabel}</span>
+												<span class="font-mono text-xs text-gray-400 dark:text-gray-500"
+													>{versionLabel}</span
+												>
 											{/if}
 											{#if activeLabel}
 												<span class="text-xs font-medium {statusText}">{activeLabel}</span>
 											{/if}
 											<div class="flex-1"></div>
 											{#if upgradeCount > 0}
-												<span class="inline-flex shrink-0 items-center gap-0.5 rounded-full bg-orange-100 px-1.5 py-0.5 text-xs font-semibold text-orange-700 dark:bg-orange-900/30 dark:text-orange-400">
+												<span
+													class="inline-flex shrink-0 items-center gap-0.5 rounded-full bg-orange-100 px-1.5 py-0.5 text-xs font-semibold text-orange-700 dark:bg-orange-900/30 dark:text-orange-400"
+												>
 													<ArrowUpOutline class="h-2.5 w-2.5" />{upgradeCount}
 												</span>
 											{/if}
 											{#if failedHCCount > 0}
-												<span class="inline-flex shrink-0 items-center gap-0.5 rounded-full bg-red-100 px-1.5 py-0.5 text-xs font-semibold text-red-700 dark:bg-red-900/30 dark:text-red-400">
+												<span
+													class="inline-flex shrink-0 items-center gap-0.5 rounded-full bg-red-100 px-1.5 py-0.5 text-xs font-semibold text-red-700 dark:bg-red-900/30 dark:text-red-400"
+												>
 													<HeartSolid class="h-2.5 w-2.5" />{failedHCCount}
 												</span>
 											{/if}
 										</div>
 										{#if bakeProgressPct !== null}
 											<div class="h-0.5 w-full bg-gray-100 dark:bg-gray-700">
-												<div class="h-full bg-yellow-400 transition-all duration-300 dark:bg-yellow-500" style="width: {bakeProgressPct}%"></div>
+												<div
+													class="h-full bg-yellow-400 transition-all duration-300 dark:bg-yellow-500"
+													style="width: {bakeProgressPct}%"
+												></div>
 											</div>
 										{/if}
 									</a>
@@ -337,5 +443,4 @@
 			{/if}
 		</div>
 	</div>
-
 </div>

--- a/frontend/src/lib/Rollouts.svelte
+++ b/frontend/src/lib/Rollouts.svelte
@@ -295,21 +295,19 @@
 									<a
 										href="/rollouts/{ns}/{name}"
 										style={rolloutTheme ? getEnvironmentThemeStyle(rolloutTheme) : undefined}
-										class="environment-theme-scope group flex flex-col overflow-hidden rounded-lg border transition-colors
+										class="environment-theme-scope group relative flex flex-col overflow-hidden rounded-lg border transition-colors
 											{status === 'Failed'
 												? 'border-red-200 bg-red-50 hover:border-red-300 dark:border-red-900/50 dark:bg-red-950/20 dark:hover:border-red-800'
-												: rolloutTheme
-													? 'environment-theme-card'
 												: 'border-gray-200 bg-white hover:border-gray-300 dark:border-gray-700 dark:bg-gray-800 dark:hover:border-gray-600'}"
 									>
 										{#if rolloutTheme}
-											<div class="h-1 w-full environment-theme-accent" aria-hidden="true"></div>
+											<div class="absolute inset-y-0 left-0 w-1 environment-theme-accent opacity-70" aria-hidden="true"></div>
 										{/if}
 										<div class="flex items-center gap-2 px-3 pt-2.5 pb-1.5">
 											<BakeStatusIcon bakeStatus={status} size="small" class="shrink-0" />
 											<span class="min-w-0 flex-1 truncate text-sm font-medium text-gray-900 dark:text-white">{name}</span>
 											{#if rolloutTheme}
-												<span class="environment-theme-surface shrink-0 rounded-full px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider">
+												<span class="environment-theme-badge shrink-0 rounded-full px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider">
 													{rolloutTheme.label}
 												</span>
 											{/if}

--- a/frontend/src/lib/Rollouts.svelte
+++ b/frontend/src/lib/Rollouts.svelte
@@ -16,31 +16,31 @@
 	);
 
 	const rollouts = $derived<Rollout[]>(rolloutsQuery.data?.rollouts?.items || []);
-	const loading = $derived(rolloutsQuery.isLoading);
-	const error = $derived(
+	const loading  = $derived(rolloutsQuery.isLoading);
+	const error    = $derived(
 		rolloutsQuery.isError ? (rolloutsQuery.error as Error).message || 'Unknown error' : null
 	);
 
-	let searchQuery = $state('');
+	let searchQuery     = $state('');
 	let namespaceFilter = $state('all');
-	let statusFilter = $state('all');
+	let statusFilter    = $state('all');
 
 	const uniqueNamespaces = $derived(
 		[...new Set(rollouts.map((r) => r.metadata?.namespace || 'default'))].sort()
 	);
 
 	const STATUS_TEXT: Record<string, string> = {
-		Succeeded: 'text-green-600 dark:text-green-400',
-		Failed: 'text-red-600 dark:text-red-400',
+		Succeeded:  'text-green-600 dark:text-green-400',
+		Failed:     'text-red-600 dark:text-red-400',
 		InProgress: 'text-yellow-600 dark:text-yellow-400',
-		Deploying: 'text-blue-600 dark:text-blue-400',
-		Cancelled: 'text-gray-500 dark:text-gray-400',
-		None: 'text-gray-400 dark:text-gray-500'
+		Deploying:  'text-blue-600 dark:text-blue-400',
+		Cancelled:  'text-gray-500 dark:text-gray-400',
+		None:       'text-gray-400 dark:text-gray-500',
 	};
 
 	const ACTIVE_LABEL: Record<string, string> = {
 		InProgress: 'Baking',
-		Deploying: 'Deploying'
+		Deploying:  'Deploying',
 	};
 
 	function getBakeStatus(r: Rollout): string {
@@ -49,8 +49,8 @@
 
 	function compactTime(timestamp: string, n: Date): string {
 		const s = Math.floor((n.getTime() - new Date(timestamp).getTime()) / 1000);
-		if (s < 60) return `${s}s`;
-		if (s < 3600) return `${Math.floor(s / 60)}m`;
+		if (s < 60)    return `${s}s`;
+		if (s < 3600)  return `${Math.floor(s / 60)}m`;
 		if (s < 86400) return `${Math.floor(s / 3600)}h`;
 		return `${Math.floor(s / 86400)}d`;
 	}
@@ -60,45 +60,34 @@
 		if (!m) return 0;
 		const v = parseInt(m[1]);
 		switch (m[2]) {
-			case 's':
-				return v * 1000;
-			case 'm':
-				return v * 60000;
-			case 'h':
-				return v * 3600000;
-			case 'd':
-				return v * 86400000;
-			default:
-				return 0;
+			case 's': return v * 1000;
+			case 'm': return v * 60000;
+			case 'h': return v * 3600000;
+			case 'd': return v * 86400000;
+			default:  return 0;
 		}
 	}
 
 	const STATUS_SORT: Record<string, number> = {
-		Failed: 0,
-		InProgress: 1,
-		Deploying: 2,
-		None: 3,
-		Cancelled: 4,
-		Succeeded: 5
+		Failed: 0, InProgress: 1, Deploying: 2, None: 3, Cancelled: 4, Succeeded: 5
 	};
 
 	const filteredRolloutsByNamespace = $derived.by(() => {
 		const filtered = rollouts
 			.filter((r) => {
-				const ns = r.metadata?.namespace || 'default';
+				const ns   = r.metadata?.namespace || 'default';
 				const name = r.metadata?.name || '';
-				const st = getBakeStatus(r);
-				const matchesSearch =
-					searchQuery === '' ||
+				const st   = getBakeStatus(r);
+				const matchesSearch = searchQuery === '' ||
 					name.toLowerCase().includes(searchQuery.toLowerCase()) ||
 					ns.toLowerCase().includes(searchQuery.toLowerCase());
 				const matchesNs = namespaceFilter === 'all' || ns === namespaceFilter;
 				const matchesStatus =
-					statusFilter === 'all' ||
-					(statusFilter === 'active' && (st === 'InProgress' || st === 'Deploying')) ||
-					(statusFilter === 'failed' && st === 'Failed') ||
+					statusFilter === 'all'       ||
+					(statusFilter === 'active'    && (st === 'InProgress' || st === 'Deploying')) ||
+					(statusFilter === 'failed'    && st === 'Failed') ||
 					(statusFilter === 'succeeded' && st === 'Succeeded') ||
-					(statusFilter === 'idle' && st === 'None');
+					(statusFilter === 'idle'      && st === 'None');
 				return matchesSearch && matchesNs && matchesStatus;
 			})
 			.sort((a, b) => {
@@ -112,9 +101,7 @@
 			if (!grouped[ns]) grouped[ns] = [];
 			grouped[ns].push(r);
 		});
-		return Object.keys(grouped)
-			.sort()
-			.map((ns) => ({ ns, rollouts: grouped[ns] }));
+		return Object.keys(grouped).sort().map((ns) => ({ ns, rollouts: grouped[ns] }));
 	});
 
 	const totalFiltered = $derived(
@@ -126,9 +113,9 @@
 		rollouts.forEach((r) => {
 			const st = getBakeStatus(r);
 			if (st === 'InProgress' || st === 'Deploying') c.active++;
-			else if (st === 'Failed') c.failed++;
+			else if (st === 'Failed')    c.failed++;
 			else if (st === 'Succeeded') c.succeeded++;
-			else if (st === 'None') c.idle++;
+			else if (st === 'None')      c.idle++;
 		});
 		return c;
 	});
@@ -144,139 +131,86 @@
 </script>
 
 <div class="flex h-full overflow-hidden">
+
 	<!-- ── Sidebar (desktop only) ── -->
 	<div class="hidden lg:block">
 		<Sidebar class="h-full border-r border-gray-200 dark:border-gray-700" position="static">
 			<div class="flex flex-col gap-4 px-3 py-4">
+
 				<!-- Search -->
 				<div class="relative">
-					<SearchOutline
-						class="pointer-events-none absolute top-1/2 left-2.5 h-3.5 w-3.5 -translate-y-1/2 text-gray-400"
-					/>
+					<SearchOutline class="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-gray-400" />
 					<input
 						type="search"
 						placeholder="Search…"
 						bind:value={searchQuery}
-						class="w-full rounded-md border border-gray-200 bg-gray-50 py-1.5 pr-2 pl-8 text-sm text-gray-900 placeholder-gray-400 focus:border-transparent focus:ring-2 focus:ring-blue-500 focus:outline-none dark:border-gray-700 dark:bg-gray-800 dark:text-white"
+						class="w-full rounded-md border border-gray-200 bg-gray-50 py-1.5 pl-8 pr-2 text-sm text-gray-900 placeholder-gray-400 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white"
 					/>
 				</div>
 
 				<!-- Status filter group -->
 				<SidebarGroup>
-					<p
-						class="mb-1 px-3 text-[11px] font-semibold tracking-widest text-gray-400 uppercase dark:text-gray-500"
-					>
-						Status
-					</p>
-					<button
-						onclick={() => (statusFilter = 'all')}
-						class={sidebarItemClass(statusFilter === 'all')}
-					>
+					<p class="mb-1 px-3 text-[11px] font-semibold uppercase tracking-widest text-gray-400 dark:text-gray-500">Status</p>
+					<button onclick={() => (statusFilter = 'all')} class={sidebarItemClass(statusFilter === 'all')}>
 						All
-						<span class="text-xs text-gray-400 tabular-nums dark:text-gray-500"
-							>{rollouts.length}</span
-						>
+						<span class="text-xs tabular-nums text-gray-400 dark:text-gray-500">{rollouts.length}</span>
 					</button>
-					<button
-						onclick={() => (statusFilter = 'active')}
-						class={sidebarItemClass(statusFilter === 'active')}
-					>
-						<span class="flex items-center gap-2"
-							><span class="h-2 w-2 rounded-full bg-yellow-400"></span>Active</span
-						>
-						<span
-							class="text-xs tabular-nums {statusCounts.active > 0
-								? 'text-gray-500 dark:text-gray-400'
-								: 'text-gray-300 dark:text-gray-600'}">{statusCounts.active}</span
-						>
+					<button onclick={() => (statusFilter = 'active')} class={sidebarItemClass(statusFilter === 'active')}>
+						<span class="flex items-center gap-2"><span class="h-2 w-2 rounded-full bg-yellow-400"></span>Active</span>
+						<span class="text-xs tabular-nums {statusCounts.active > 0 ? 'text-gray-500 dark:text-gray-400' : 'text-gray-300 dark:text-gray-600'}">{statusCounts.active}</span>
 					</button>
-					<button
-						onclick={() => (statusFilter = 'failed')}
-						class={sidebarItemClass(statusFilter === 'failed')}
-					>
-						<span class="flex items-center gap-2"
-							><span class="h-2 w-2 rounded-full bg-red-500"></span>Failed</span
-						>
-						<span
-							class="text-xs tabular-nums {statusCounts.failed > 0
-								? 'font-semibold text-red-600 dark:text-red-400'
-								: 'text-gray-300 dark:text-gray-600'}">{statusCounts.failed}</span
-						>
+					<button onclick={() => (statusFilter = 'failed')} class={sidebarItemClass(statusFilter === 'failed')}>
+						<span class="flex items-center gap-2"><span class="h-2 w-2 rounded-full bg-red-500"></span>Failed</span>
+						<span class="text-xs tabular-nums {statusCounts.failed > 0 ? 'font-semibold text-red-600 dark:text-red-400' : 'text-gray-300 dark:text-gray-600'}">{statusCounts.failed}</span>
 					</button>
-					<button
-						onclick={() => (statusFilter = 'succeeded')}
-						class={sidebarItemClass(statusFilter === 'succeeded')}
-					>
-						<span class="flex items-center gap-2"
-							><span class="h-2 w-2 rounded-full bg-green-500"></span>Succeeded</span
-						>
-						<span class="text-xs text-gray-400 tabular-nums dark:text-gray-500"
-							>{statusCounts.succeeded}</span
-						>
+					<button onclick={() => (statusFilter = 'succeeded')} class={sidebarItemClass(statusFilter === 'succeeded')}>
+						<span class="flex items-center gap-2"><span class="h-2 w-2 rounded-full bg-green-500"></span>Succeeded</span>
+						<span class="text-xs tabular-nums text-gray-400 dark:text-gray-500">{statusCounts.succeeded}</span>
 					</button>
-					<button
-						onclick={() => (statusFilter = 'idle')}
-						class={sidebarItemClass(statusFilter === 'idle')}
-					>
-						<span class="flex items-center gap-2"
-							><span class="h-2 w-2 rounded-full bg-gray-300 dark:bg-gray-600"></span>Idle</span
-						>
-						<span class="text-xs text-gray-400 tabular-nums dark:text-gray-500"
-							>{statusCounts.idle}</span
-						>
+					<button onclick={() => (statusFilter = 'idle')} class={sidebarItemClass(statusFilter === 'idle')}>
+						<span class="flex items-center gap-2"><span class="h-2 w-2 rounded-full bg-gray-300 dark:bg-gray-600"></span>Idle</span>
+						<span class="text-xs tabular-nums text-gray-400 dark:text-gray-500">{statusCounts.idle}</span>
 					</button>
 				</SidebarGroup>
 
 				<!-- Namespace filter group -->
 				{#if uniqueNamespaces.length > 1}
 					<SidebarGroup border>
-						<p
-							class="mb-1 px-3 text-[11px] font-semibold tracking-widest text-gray-400 uppercase dark:text-gray-500"
-						>
-							Namespace
-						</p>
-						<button
-							onclick={() => (namespaceFilter = 'all')}
-							class={sidebarItemClass(namespaceFilter === 'all')}>All</button
-						>
+						<p class="mb-1 px-3 text-[11px] font-semibold uppercase tracking-widest text-gray-400 dark:text-gray-500">Namespace</p>
+						<button onclick={() => (namespaceFilter = 'all')} class={sidebarItemClass(namespaceFilter === 'all')}>All</button>
 						{#each uniqueNamespaces as ns}
-							<button
-								onclick={() => (namespaceFilter = ns)}
-								class={sidebarItemClass(namespaceFilter === ns)}
-							>
+							<button onclick={() => (namespaceFilter = ns)} class={sidebarItemClass(namespaceFilter === ns)}>
 								<span class="truncate">{ns}</span>
 							</button>
 						{/each}
 					</SidebarGroup>
 				{/if}
+
 			</div>
 		</Sidebar>
 	</div>
 
 	<!-- ── Right side: mobile filter bar + cards ── -->
 	<div class="flex min-w-0 flex-1 flex-col overflow-hidden">
+
 		<!-- Mobile filter bar (hidden on desktop) -->
-		<div
-			class="sticky top-0 z-10 border-b border-gray-200 bg-white lg:hidden dark:border-gray-700 dark:bg-gray-900"
-		>
+		<div class="sticky top-0 z-10 border-b border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900 lg:hidden">
 			<div class="flex flex-col gap-2 px-3 py-2.5">
 				<!-- Search -->
 				<div class="relative">
-					<SearchOutline
-						class="pointer-events-none absolute top-1/2 left-2.5 h-3.5 w-3.5 -translate-y-1/2 text-gray-400"
-					/>
+					<SearchOutline class="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-gray-400" />
 					<input
 						type="search"
 						placeholder="Search rollouts…"
 						bind:value={searchQuery}
-						class="w-full rounded-md border border-gray-200 bg-gray-50 py-1.5 pr-2 pl-8 text-sm text-gray-900 placeholder-gray-400 focus:border-transparent focus:ring-2 focus:ring-blue-500 focus:outline-none dark:border-gray-700 dark:bg-gray-800 dark:text-white"
+						class="w-full rounded-md border border-gray-200 bg-gray-50 py-1.5 pl-8 pr-2 text-sm text-gray-900 placeholder-gray-400 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white"
 					/>
 				</div>
 				<!-- Selects row -->
 				<div class="flex gap-2">
 					<select
 						bind:value={statusFilter}
-						class="min-w-0 flex-1 rounded-md border border-gray-200 bg-gray-50 px-2 py-1.5 text-sm text-gray-700 focus:ring-2 focus:ring-blue-500 focus:outline-none dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300"
+						class="min-w-0 flex-1 rounded-md border border-gray-200 bg-gray-50 py-1.5 px-2 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300"
 					>
 						<option value="all">All statuses</option>
 						<option value="active">Active ({statusCounts.active})</option>
@@ -287,7 +221,7 @@
 					{#if uniqueNamespaces.length > 1}
 						<select
 							bind:value={namespaceFilter}
-							class="min-w-0 flex-1 rounded-md border border-gray-200 bg-gray-50 px-2 py-1.5 text-sm text-gray-700 focus:ring-2 focus:ring-blue-500 focus:outline-none dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300"
+							class="min-w-0 flex-1 rounded-md border border-gray-200 bg-gray-50 py-1.5 px-2 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300"
 						>
 							<option value="all">All namespaces</option>
 							{#each uniqueNamespaces as ns}
@@ -306,9 +240,7 @@
 					{#each Array(6) as _}
 						<div class="rounded-lg border border-gray-200 p-3 dark:border-gray-700">
 							<div class="flex items-center gap-2.5">
-								<div
-									class="h-3 w-3 shrink-0 animate-pulse rounded-full bg-gray-200 dark:bg-gray-700"
-								></div>
+								<div class="h-3 w-3 shrink-0 animate-pulse rounded-full bg-gray-200 dark:bg-gray-700"></div>
 								<div class="h-3 flex-1 animate-pulse rounded bg-gray-200 dark:bg-gray-700"></div>
 								<div class="h-3 w-8 animate-pulse rounded bg-gray-200 dark:bg-gray-700"></div>
 							</div>
@@ -326,14 +258,9 @@
 				<div class="py-16 text-center">
 					<p class="text-sm text-gray-500 dark:text-gray-400">No results.</p>
 					<button
-						onclick={() => {
-							searchQuery = '';
-							namespaceFilter = 'all';
-							statusFilter = 'all';
-						}}
+						onclick={() => { searchQuery = ''; namespaceFilter = 'all'; statusFilter = 'all'; }}
 						class="mt-2 text-xs text-blue-600 hover:underline dark:text-blue-400"
-						>Clear filters</button
-					>
+					>Clear filters</button>
 				</div>
 			{:else}
 				<div class="flex flex-col gap-4 p-3 sm:p-4">
@@ -341,29 +268,25 @@
 						<div>
 							{#if filteredRolloutsByNamespace.length > 1}
 								<div class="mb-2 flex items-center gap-2.5">
-									<span
-										class="shrink-0 text-[11px] font-semibold tracking-widest text-gray-400 uppercase dark:text-gray-500"
-										>{group.ns}</span
-									>
+									<span class="shrink-0 text-[11px] font-semibold uppercase tracking-widest text-gray-400 dark:text-gray-500">{group.ns}</span>
 									<div class="h-px flex-1 bg-gray-200 dark:bg-gray-700"></div>
 								</div>
 							{/if}
 
 							<div class="grid grid-cols-1 gap-2 sm:grid-cols-2 xl:grid-cols-3">
 								{#each group.rollouts as r}
-									{@const ns = r.metadata?.namespace || 'default'}
-									{@const name = r.metadata?.name || ''}
-									{@const latest = r.status?.history?.[0]}
-									{@const status = getBakeStatus(r)}
-									{@const versionLabel = latest?.version ? getDisplayVersion(latest.version) : null}
-									{@const upgradeCount = r.status?.releaseCandidates?.length || 0}
+									{@const ns            = r.metadata?.namespace || 'default'}
+									{@const name          = r.metadata?.name || ''}
+									{@const latest        = r.status?.history?.[0]}
+									{@const status        = getBakeStatus(r)}
+									{@const versionLabel  = latest?.version ? getDisplayVersion(latest.version) : null}
+									{@const upgradeCount  = r.status?.releaseCandidates?.length || 0}
 									{@const failedHCCount = latest?.failedHealthChecks?.length || 0}
-									{@const activeLabel = ACTIVE_LABEL[status] ?? null}
-									{@const statusText = STATUS_TEXT[status] ?? STATUS_TEXT['None']}
-									{@const rolloutTheme = getRolloutEnvironmentTheme(r)}
+									{@const activeLabel   = ACTIVE_LABEL[status] ?? null}
+									{@const statusText    = STATUS_TEXT[status] ?? STATUS_TEXT['None']}
+									{@const rolloutTheme  = getRolloutEnvironmentTheme(r)}
 									{@const bakeProgressPct = (() => {
-										if (status !== 'InProgress' || !latest?.bakeStartTime || !r.spec?.bakeTime)
-											return null;
+										if (status !== 'InProgress' || !latest?.bakeStartTime || !r.spec?.bakeTime) return null;
 										const elapsed = $now.getTime() - new Date(latest.bakeStartTime).getTime();
 										const total = parseDuration(r.spec.bakeTime);
 										return total > 0 ? Math.min(100, Math.max(0, (elapsed / total) * 100)) : null;
@@ -374,64 +297,48 @@
 										style={rolloutTheme ? getEnvironmentThemeStyle(rolloutTheme) : undefined}
 										class="environment-theme-scope group flex flex-col overflow-hidden rounded-lg border transition-colors
 											{status === 'Failed'
-											? 'border-red-200 bg-red-50 hover:border-red-300 dark:border-red-900/50 dark:bg-red-950/20 dark:hover:border-red-800'
-											: rolloutTheme
-												? 'environment-theme-card'
+												? 'border-red-200 bg-red-50 hover:border-red-300 dark:border-red-900/50 dark:bg-red-950/20 dark:hover:border-red-800'
+												: rolloutTheme
+													? 'environment-theme-card'
 												: 'border-gray-200 bg-white hover:border-gray-300 dark:border-gray-700 dark:bg-gray-800 dark:hover:border-gray-600'}"
 									>
 										{#if rolloutTheme}
-											<div class="environment-theme-accent h-1 w-full" aria-hidden="true"></div>
+											<div class="h-1 w-full environment-theme-accent" aria-hidden="true"></div>
 										{/if}
 										<div class="flex items-center gap-2 px-3 pt-2.5 pb-1.5">
 											<BakeStatusIcon bakeStatus={status} size="small" class="shrink-0" />
-											<span
-												class="min-w-0 flex-1 truncate text-sm font-medium text-gray-900 dark:text-white"
-												>{name}</span
-											>
+											<span class="min-w-0 flex-1 truncate text-sm font-medium text-gray-900 dark:text-white">{name}</span>
 											{#if rolloutTheme}
-												<span
-													class="environment-theme-surface shrink-0 rounded-full px-1.5 py-0.5 text-[9px] font-semibold tracking-wider uppercase"
-												>
+												<span class="environment-theme-surface shrink-0 rounded-full px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider">
 													{rolloutTheme.label}
 												</span>
 											{/if}
 											{#if latest?.timestamp}
-												<span class="shrink-0 text-xs text-gray-400 tabular-nums dark:text-gray-500"
-													>{compactTime(latest.timestamp, $now)}</span
-												>
+												<span class="shrink-0 text-xs tabular-nums text-gray-400 dark:text-gray-500">{compactTime(latest.timestamp, $now)}</span>
 											{/if}
 										</div>
 										<div class="flex min-h-[1.75rem] items-center gap-1.5 px-3 pb-2.5 pl-7">
 											{#if versionLabel}
-												<span class="font-mono text-xs text-gray-400 dark:text-gray-500"
-													>{versionLabel}</span
-												>
+												<span class="font-mono text-xs text-gray-400 dark:text-gray-500">{versionLabel}</span>
 											{/if}
 											{#if activeLabel}
 												<span class="text-xs font-medium {statusText}">{activeLabel}</span>
 											{/if}
 											<div class="flex-1"></div>
 											{#if upgradeCount > 0}
-												<span
-													class="inline-flex shrink-0 items-center gap-0.5 rounded-full bg-orange-100 px-1.5 py-0.5 text-xs font-semibold text-orange-700 dark:bg-orange-900/30 dark:text-orange-400"
-												>
+												<span class="inline-flex shrink-0 items-center gap-0.5 rounded-full bg-orange-100 px-1.5 py-0.5 text-xs font-semibold text-orange-700 dark:bg-orange-900/30 dark:text-orange-400">
 													<ArrowUpOutline class="h-2.5 w-2.5" />{upgradeCount}
 												</span>
 											{/if}
 											{#if failedHCCount > 0}
-												<span
-													class="inline-flex shrink-0 items-center gap-0.5 rounded-full bg-red-100 px-1.5 py-0.5 text-xs font-semibold text-red-700 dark:bg-red-900/30 dark:text-red-400"
-												>
+												<span class="inline-flex shrink-0 items-center gap-0.5 rounded-full bg-red-100 px-1.5 py-0.5 text-xs font-semibold text-red-700 dark:bg-red-900/30 dark:text-red-400">
 													<HeartSolid class="h-2.5 w-2.5" />{failedHCCount}
 												</span>
 											{/if}
 										</div>
 										{#if bakeProgressPct !== null}
 											<div class="h-0.5 w-full bg-gray-100 dark:bg-gray-700">
-												<div
-													class="h-full bg-yellow-400 transition-all duration-300 dark:bg-yellow-500"
-													style="width: {bakeProgressPct}%"
-												></div>
+												<div class="h-full bg-yellow-400 transition-all duration-300 dark:bg-yellow-500" style="width: {bakeProgressPct}%"></div>
 											</div>
 										{/if}
 									</a>
@@ -443,4 +350,5 @@
 			{/if}
 		</div>
 	</div>
+
 </div>

--- a/frontend/src/lib/components/JoinedBadge.svelte
+++ b/frontend/src/lib/components/JoinedBadge.svelte
@@ -15,6 +15,7 @@
 		containerClass?: string;
 		containerStyle?: string;
 		labelClass?: string;
+		labelBorder?: boolean;
 		valueClass?: string;
 	}
 
@@ -28,6 +29,7 @@
 		containerClass = '',
 		containerStyle,
 		labelClass = '',
+		labelBorder = false,
 		valueClass = ''
 	}: Props = $props();
 
@@ -36,7 +38,12 @@
 
 <div class="inline-flex items-center {containerClass}" style={containerStyle}>
 	<!-- Left part: Label with optional icon -->
-	<Badge color="gray" {large} class="flex items-center gap-1.5 rounded-r-none border-r-0 {labelClass}">
+	<Badge
+		color="gray"
+		{large}
+		border={labelBorder}
+		class="flex items-center gap-1.5 rounded-r-none border-r-0 {labelClass}"
+	>
 		{#if icon}
 			{@render icon()}
 		{/if}

--- a/frontend/src/lib/components/JoinedBadge.svelte
+++ b/frontend/src/lib/components/JoinedBadge.svelte
@@ -12,16 +12,31 @@
 		valueColor?: 'green' | 'red' | 'yellow' | 'blue' | 'gray' | 'purple' | 'pink' | 'indigo';
 		large?: boolean;
 		href?: string;
+		containerClass?: string;
+		containerStyle?: string;
+		labelClass?: string;
+		valueClass?: string;
 	}
 
-	let { label, value, icon, valueColor = 'gray', large = false, href }: Props = $props();
+	let {
+		label,
+		value,
+		icon,
+		valueColor = 'gray',
+		large = false,
+		href,
+		containerClass = '',
+		containerStyle,
+		labelClass = '',
+		valueClass = ''
+	}: Props = $props();
 
 	const hasLink = $derived(!!href);
 </script>
 
-<div class="inline-flex items-center">
+<div class="inline-flex items-center {containerClass}" style={containerStyle}>
 	<!-- Left part: Label with optional icon -->
-	<Badge color="gray" {large} class="flex items-center gap-1.5 rounded-r-none border-r-0">
+	<Badge color="gray" {large} class="flex items-center gap-1.5 rounded-r-none border-r-0 {labelClass}">
 		{#if icon}
 			{@render icon()}
 		{/if}
@@ -31,13 +46,13 @@
 	<!-- Right part: Value -->
 	{#if hasLink}
 		<a {href} target="_blank" rel="noopener noreferrer" class="inline-flex items-center">
-			<Badge color={valueColor} {large} class="flex items-center gap-1 rounded-l-none">
+			<Badge color={valueColor} {large} class="flex items-center gap-1 rounded-l-none {valueClass}">
 				{value}
 				<ArrowUpRightFromSquareOutline class="h-3 w-3 flex-shrink-0" />
 			</Badge>
 		</a>
 	{:else}
-		<Badge color={valueColor} {large} class="flex items-center gap-1 rounded-l-none">
+		<Badge color={valueColor} {large} class="flex items-center gap-1 rounded-l-none {valueClass}">
 			{value}
 		</Badge>
 	{/if}

--- a/frontend/src/lib/components/JoinedBadge.svelte
+++ b/frontend/src/lib/components/JoinedBadge.svelte
@@ -16,6 +16,7 @@
 		containerStyle?: string;
 		labelClass?: string;
 		labelBorder?: boolean;
+		labelPlainBorder?: boolean;
 		valueClass?: string;
 	}
 
@@ -30,10 +31,14 @@
 		containerStyle,
 		labelClass = '',
 		labelBorder = false,
+		labelPlainBorder = false,
 		valueClass = ''
 	}: Props = $props();
 
 	const hasLink = $derived(!!href);
+	const labelPlainBorderClass = $derived(
+		labelPlainBorder ? 'border-y border-l border-gray-300 dark:border-gray-600' : ''
+	);
 </script>
 
 <div class="inline-flex items-center {containerClass}" style={containerStyle}>
@@ -42,7 +47,7 @@
 		color="gray"
 		{large}
 		border={labelBorder}
-		class="flex items-center gap-1.5 rounded-r-none border-r-0 {labelClass}"
+		class="flex items-center gap-1.5 rounded-r-none border-r-0 {labelPlainBorderClass} {labelClass}"
 	>
 		{#if icon}
 			{@render icon()}

--- a/frontend/src/lib/environment-theme.ts
+++ b/frontend/src/lib/environment-theme.ts
@@ -29,7 +29,7 @@ const PRESET_THEMES: Record<string, ThemePreset> = {
 	testing: { label: 'Test', color: '#0891b2' }
 };
 
-const ENVIRONMENT_MATCHERS: { pattern: RegExp; preset: string }[] = [
+const ENVIRONMENT_MATCHERS: { pattern: RegExp; preset: keyof typeof PRESET_THEMES }[] = [
 	{ pattern: /prod|production/i, preset: 'prod' },
 	{ pattern: /dev|development/i, preset: 'dev' },
 	{ pattern: /staging|stage/i, preset: 'staging' },
@@ -81,9 +81,31 @@ function labelFromThemeName(name: string): string {
 		.join(' ');
 }
 
-function presetNameFromEnvironmentName(environmentName: string): string | null {
+function presetNameFromEnvironmentName(environmentName: string): keyof typeof PRESET_THEMES | null {
 	const match = ENVIRONMENT_MATCHERS.find(({ pattern }) => pattern.test(environmentName));
 	return match?.preset ?? null;
+}
+
+function resolveThemeLabel({
+	annotationLabel,
+	environmentName,
+	inlineThemeColor,
+	preset,
+	themeName,
+	themeValue
+}: {
+	annotationLabel?: string;
+	environmentName?: string;
+	inlineThemeColor: string | null;
+	preset?: ThemePreset;
+	themeName: string;
+	themeValue?: string;
+}): string {
+	if (annotationLabel) return annotationLabel;
+	if (themeValue && preset) return preset.label;
+	if (themeValue && inlineThemeColor) return environmentName || 'Custom';
+	if (themeName === 'custom') return environmentName || 'Custom';
+	return environmentName || preset?.label || labelFromThemeName(themeName);
 }
 
 function buildEnvironmentTheme(name: string, label: string, color: string): EnvironmentTheme {
@@ -121,11 +143,14 @@ export function getRolloutEnvironmentTheme(
 	const color = customColor ?? inlineThemeColor ?? preset?.color;
 	if (!color) return null;
 
-	const label =
-		annotations?.[ENVIRONMENT_THEME_LABEL_ANNOTATION]?.trim() ||
-		environmentName ||
-		preset?.label ||
-		(themeName === 'custom' ? 'Custom' : labelFromThemeName(themeName));
+	const label = resolveThemeLabel({
+		annotationLabel: annotations?.[ENVIRONMENT_THEME_LABEL_ANNOTATION]?.trim(),
+		environmentName,
+		inlineThemeColor,
+		preset,
+		themeName,
+		themeValue
+	});
 
 	return buildEnvironmentTheme(themeName, label, color);
 }

--- a/frontend/src/lib/environment-theme.ts
+++ b/frontend/src/lib/environment-theme.ts
@@ -1,4 +1,4 @@
-import type { Rollout } from '../types';
+import type { Environment, Rollout } from '../types';
 
 export const ENVIRONMENT_THEME_ANNOTATION = 'dashboard.rollout.kuberik.com/theme';
 export const ENVIRONMENT_THEME_COLOR_ANNOTATION = 'dashboard.rollout.kuberik.com/theme-color';
@@ -28,6 +28,13 @@ const PRESET_THEMES: Record<string, ThemePreset> = {
 	test: { label: 'Test', color: '#0891b2' },
 	testing: { label: 'Test', color: '#0891b2' }
 };
+
+const ENVIRONMENT_MATCHERS: { pattern: RegExp; preset: string }[] = [
+	{ pattern: /prod|production/i, preset: 'prod' },
+	{ pattern: /dev|development/i, preset: 'dev' },
+	{ pattern: /staging|stage/i, preset: 'staging' },
+	{ pattern: /test|testing/i, preset: 'test' }
+];
 
 const HEX_COLOR_REGEX = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
 
@@ -74,6 +81,11 @@ function labelFromThemeName(name: string): string {
 		.join(' ');
 }
 
+function presetNameFromEnvironmentName(environmentName: string): string | null {
+	const match = ENVIRONMENT_MATCHERS.find(({ pattern }) => pattern.test(environmentName));
+	return match?.preset ?? null;
+}
+
 function buildEnvironmentTheme(name: string, label: string, color: string): EnvironmentTheme {
 	const normalizedColor = normalizeHexColor(color) ?? '#2563eb';
 	return {
@@ -88,15 +100,21 @@ function buildEnvironmentTheme(name: string, label: string, color: string): Envi
 	};
 }
 
-export function getRolloutEnvironmentTheme(rollout?: Rollout | null): EnvironmentTheme | null {
+export function getRolloutEnvironmentTheme(
+	rollout?: Rollout | null,
+	environment?: Environment | string | null
+): EnvironmentTheme | null {
 	const annotations = rollout?.metadata?.annotations;
-	if (!annotations) return null;
+	const environmentName = typeof environment === 'string' ? environment : environment?.spec?.environment;
 
-	const themeValue = annotations[ENVIRONMENT_THEME_ANNOTATION]?.trim();
-	const colorValue = annotations[ENVIRONMENT_THEME_COLOR_ANNOTATION]?.trim();
-	if (!themeValue && !colorValue) return null;
+	const themeValue = annotations?.[ENVIRONMENT_THEME_ANNOTATION]?.trim();
+	const colorValue = annotations?.[ENVIRONMENT_THEME_COLOR_ANNOTATION]?.trim();
+	if (!themeValue && !colorValue && !environmentName) return null;
 
-	const themeName = themeValue ? normalizeThemeName(themeValue) : 'custom';
+	const inferredPresetName = environmentName ? presetNameFromEnvironmentName(environmentName) : null;
+	const themeName = themeValue
+		? normalizeThemeName(themeValue)
+		: (inferredPresetName ?? (colorValue ? 'custom' : ''));
 	const preset = themeName ? PRESET_THEMES[themeName] : undefined;
 	const customColor = colorValue ? normalizeHexColor(colorValue) : null;
 	const inlineThemeColor = themeValue ? normalizeHexColor(themeValue) : null;
@@ -104,7 +122,8 @@ export function getRolloutEnvironmentTheme(rollout?: Rollout | null): Environmen
 	if (!color) return null;
 
 	const label =
-		annotations[ENVIRONMENT_THEME_LABEL_ANNOTATION]?.trim() ||
+		annotations?.[ENVIRONMENT_THEME_LABEL_ANNOTATION]?.trim() ||
+		environmentName ||
 		preset?.label ||
 		(themeName === 'custom' ? 'Custom' : labelFromThemeName(themeName));
 

--- a/frontend/src/lib/environment-theme.ts
+++ b/frontend/src/lib/environment-theme.ts
@@ -1,0 +1,123 @@
+import type { Rollout } from '../types';
+
+export const ENVIRONMENT_THEME_ANNOTATION = 'dashboard.rollout.kuberik.com/theme';
+export const ENVIRONMENT_THEME_COLOR_ANNOTATION = 'dashboard.rollout.kuberik.com/theme-color';
+export const ENVIRONMENT_THEME_LABEL_ANNOTATION = 'dashboard.rollout.kuberik.com/theme-label';
+
+type ThemePreset = {
+	label: string;
+	color: string;
+};
+
+export type EnvironmentTheme = ThemePreset & {
+	name: string;
+	textColor: string;
+	borderColor: string;
+	surfaceColor: string;
+	darkSurfaceColor: string;
+	darkTextColor: string;
+};
+
+const PRESET_THEMES: Record<string, ThemePreset> = {
+	dev: { label: 'Development', color: '#16a34a' },
+	development: { label: 'Development', color: '#16a34a' },
+	prod: { label: 'Production', color: '#d97706' },
+	production: { label: 'Production', color: '#d97706' },
+	stage: { label: 'Staging', color: '#7c3aed' },
+	staging: { label: 'Staging', color: '#7c3aed' },
+	test: { label: 'Test', color: '#0891b2' },
+	testing: { label: 'Test', color: '#0891b2' }
+};
+
+const HEX_COLOR_REGEX = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
+
+function normalizeThemeName(value: string): string {
+	return value.trim().toLowerCase();
+}
+
+function normalizeHexColor(value: string): string | null {
+	const trimmed = value.trim();
+	if (!HEX_COLOR_REGEX.test(trimmed)) return null;
+	if (trimmed.length === 4) {
+		const [, r, g, b] = trimmed;
+		return `#${r}${r}${g}${g}${b}${b}`.toLowerCase();
+	}
+	return trimmed.toLowerCase();
+}
+
+function hexToRgb(hex: string): { r: number; g: number; b: number } {
+	const normalized = normalizeHexColor(hex);
+	if (!normalized) return { r: 37, g: 99, b: 235 };
+	return {
+		r: parseInt(normalized.slice(1, 3), 16),
+		g: parseInt(normalized.slice(3, 5), 16),
+		b: parseInt(normalized.slice(5, 7), 16)
+	};
+}
+
+function mixWith(hex: string, mix: '#ffffff' | '#000000', amount: number): string {
+	const color = hexToRgb(hex);
+	const target = hexToRgb(mix);
+	const blend = (channel: number, targetChannel: number) =>
+		Math.round(channel * (1 - amount) + targetChannel * amount);
+	const toHex = (channel: number) => channel.toString(16).padStart(2, '0');
+	return `#${toHex(blend(color.r, target.r))}${toHex(blend(color.g, target.g))}${toHex(
+		blend(color.b, target.b)
+	)}`;
+}
+
+function labelFromThemeName(name: string): string {
+	return name
+		.split(/[-_\s]+/)
+		.filter(Boolean)
+		.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+		.join(' ');
+}
+
+function buildEnvironmentTheme(name: string, label: string, color: string): EnvironmentTheme {
+	const normalizedColor = normalizeHexColor(color) ?? '#2563eb';
+	return {
+		name,
+		label,
+		color: normalizedColor,
+		textColor: mixWith(normalizedColor, '#000000', 0.18),
+		borderColor: mixWith(normalizedColor, '#ffffff', 0.64),
+		surfaceColor: mixWith(normalizedColor, '#ffffff', 0.9),
+		darkSurfaceColor: mixWith(normalizedColor, '#000000', 0.7),
+		darkTextColor: mixWith(normalizedColor, '#ffffff', 0.42)
+	};
+}
+
+export function getRolloutEnvironmentTheme(rollout?: Rollout | null): EnvironmentTheme | null {
+	const annotations = rollout?.metadata?.annotations;
+	if (!annotations) return null;
+
+	const themeValue = annotations[ENVIRONMENT_THEME_ANNOTATION]?.trim();
+	const colorValue = annotations[ENVIRONMENT_THEME_COLOR_ANNOTATION]?.trim();
+	if (!themeValue && !colorValue) return null;
+
+	const themeName = themeValue ? normalizeThemeName(themeValue) : 'custom';
+	const preset = themeName ? PRESET_THEMES[themeName] : undefined;
+	const customColor = colorValue ? normalizeHexColor(colorValue) : null;
+	const inlineThemeColor = themeValue ? normalizeHexColor(themeValue) : null;
+	const color = customColor ?? inlineThemeColor ?? preset?.color;
+	if (!color) return null;
+
+	const label =
+		annotations[ENVIRONMENT_THEME_LABEL_ANNOTATION]?.trim() ||
+		preset?.label ||
+		(themeName === 'custom' ? 'Custom' : labelFromThemeName(themeName));
+
+	return buildEnvironmentTheme(themeName, label, color);
+}
+
+export function getEnvironmentThemeStyle(theme: EnvironmentTheme): string {
+	return [
+		`--rollout-theme-accent: ${theme.color}`,
+		`--rollout-theme-text: ${theme.textColor}`,
+		`--rollout-theme-border: ${theme.borderColor}`,
+		`--rollout-theme-surface: ${theme.surfaceColor}`,
+		`--rollout-theme-dark-surface: ${theme.darkSurfaceColor}`,
+		`--rollout-theme-dark-text: ${theme.darkTextColor}`
+	].join('; ');
+}

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -282,6 +282,38 @@ describe('environment themes', () => {
         expect(theme?.color).toBe('#16a34a');
     });
 
+    it('lets a theme annotation override the inferred environment theme', () => {
+        const theme = getRolloutEnvironmentTheme(
+            {
+                metadata: {
+                    annotations: {
+                        [ENVIRONMENT_THEME_ANNOTATION]: 'dev'
+                    }
+                }
+            } as any,
+            'eu-prod-1'
+        );
+
+        expect(theme?.label).toBe('Development');
+        expect(theme?.color).toBe('#16a34a');
+    });
+
+    it('lets a custom color annotation override the inferred environment color', () => {
+        const theme = getRolloutEnvironmentTheme(
+            {
+                metadata: {
+                    annotations: {
+                        [ENVIRONMENT_THEME_COLOR_ANNOTATION]: '#0EA5E9'
+                    }
+                }
+            } as any,
+            'eu-prod-1'
+        );
+
+        expect(theme?.label).toBe('eu-prod-1');
+        expect(theme?.color).toBe('#0ea5e9');
+    });
+
     it('maps development to the green preset theme', () => {
         const theme = getRolloutEnvironmentTheme({
             metadata: {

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -265,6 +265,23 @@ describe('environment themes', () => {
         expect(theme?.color).not.toMatch(/^#(?:dc2626|ef4444|f87171)$/);
     });
 
+    it('infers production from an Environment name containing prod', () => {
+        const theme = getRolloutEnvironmentTheme({ metadata: { annotations: {} } } as any, 'eu-prod-1');
+
+        expect(theme?.label).toBe('eu-prod-1');
+        expect(theme?.color).toBe('#d97706');
+    });
+
+    it('infers development from Environment spec.environment', () => {
+        const theme = getRolloutEnvironmentTheme(
+            { metadata: { annotations: {} } } as any,
+            { spec: { environment: 'development-west' } } as any
+        );
+
+        expect(theme?.label).toBe('development-west');
+        expect(theme?.color).toBe('#16a34a');
+    });
+
     it('maps development to the green preset theme', () => {
         const theme = getRolloutEnvironmentTheme({
             metadata: {

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -1,373 +1,493 @@
 import { describe, it, expect } from 'vitest';
-import { isFieldManaged, isFieldManagedByManager, isFieldManagedByOtherManager, parseLinkAnnotations, extractDatadogInfoFromContainers, buildDatadogTestRunsUrl, buildDatadogLogsUrl, buildDatadogTraceSearchUrl } from './utils';
+import {
+	isFieldManaged,
+	isFieldManagedByManager,
+	isFieldManagedByOtherManager,
+	parseLinkAnnotations,
+	extractDatadogInfoFromContainers,
+	buildDatadogTestRunsUrl,
+	buildDatadogLogsUrl,
+	buildDatadogTraceSearchUrl
+} from './utils';
+import {
+	ENVIRONMENT_THEME_ANNOTATION,
+	ENVIRONMENT_THEME_COLOR_ANNOTATION,
+	ENVIRONMENT_THEME_LABEL_ANNOTATION,
+	getEnvironmentThemeStyle,
+	getRolloutEnvironmentTheme
+} from './environment-theme';
 
 describe('Field Manager Validation', () => {
-    describe('isFieldManaged', () => {
-        it('should correctly parse fieldsV1 YAML structure and validate field paths', () => {
-            // Example fieldsV1 from a real Kubernetes resource
-            const fieldsV1 = {
-                'f:spec': {
-                    'f:wantedVersion': {}
-                }
-            };
+	describe('isFieldManaged', () => {
+		it('should correctly parse fieldsV1 YAML structure and validate field paths', () => {
+			// Example fieldsV1 from a real Kubernetes resource
+			const fieldsV1 = {
+				'f:spec': {
+					'f:wantedVersion': {}
+				}
+			};
 
-            expect(isFieldManaged(fieldsV1, 'spec.wantedVersion')).toBe(true);
-            expect(isFieldManaged(fieldsV1, 'spec')).toBe(true);
-            expect(isFieldManaged(fieldsV1, 'metadata.name')).toBe(false);
-            expect(isFieldManaged(fieldsV1, 'spec.otherField')).toBe(false);
-        });
+			expect(isFieldManaged(fieldsV1, 'spec.wantedVersion')).toBe(true);
+			expect(isFieldManaged(fieldsV1, 'spec')).toBe(true);
+			expect(isFieldManaged(fieldsV1, 'metadata.name')).toBe(false);
+			expect(isFieldManaged(fieldsV1, 'spec.otherField')).toBe(false);
+		});
 
-        it('should handle nested field paths correctly', () => {
-            const fieldsV1 = {
-                'f:spec': {
-                    'f:healthCheckSelector': {
-                        'f:matchLabels': {
-                            'f:app': {}
-                        }
-                    }
-                }
-            };
+		it('should handle nested field paths correctly', () => {
+			const fieldsV1 = {
+				'f:spec': {
+					'f:healthCheckSelector': {
+						'f:matchLabels': {
+							'f:app': {}
+						}
+					}
+				}
+			};
 
-            expect(isFieldManaged(fieldsV1, 'spec.healthCheckSelector.matchLabels.app')).toBe(true);
-            expect(isFieldManaged(fieldsV1, 'spec.healthCheckSelector')).toBe(true);
-            expect(isFieldManaged(fieldsV1, 'spec.healthCheckSelector.matchLabels')).toBe(true);
-            expect(isFieldManaged(fieldsV1, 'spec.healthCheckSelector.matchLabels.other')).toBe(false);
-        });
+			expect(isFieldManaged(fieldsV1, 'spec.healthCheckSelector.matchLabels.app')).toBe(true);
+			expect(isFieldManaged(fieldsV1, 'spec.healthCheckSelector')).toBe(true);
+			expect(isFieldManaged(fieldsV1, 'spec.healthCheckSelector.matchLabels')).toBe(true);
+			expect(isFieldManaged(fieldsV1, 'spec.healthCheckSelector.matchLabels.other')).toBe(false);
+		});
 
-        it('should handle empty or undefined fieldsV1', () => {
-            expect(isFieldManaged('', 'spec.wantedVersion')).toBe(false);
-            expect(isFieldManaged({}, 'spec.wantedVersion')).toBe(false);
-            expect(isFieldManaged(undefined, 'spec.wantedVersion')).toBe(false);
-        });
-    });
+		it('should handle empty or undefined fieldsV1', () => {
+			expect(isFieldManaged('', 'spec.wantedVersion')).toBe(false);
+			expect(isFieldManaged({}, 'spec.wantedVersion')).toBe(false);
+			expect(isFieldManaged(undefined, 'spec.wantedVersion')).toBe(false);
+		});
+	});
 
-    describe('isFieldManagedByManager', () => {
-        it('should correctly identify when a specific manager owns a field', () => {
-            const managedFields = [
-                {
-                    manager: 'rollout-dashboard',
-                    fieldsV1: {
-                        'f:spec': {
-                            'f:wantedVersion': {}
-                        }
-                    }
-                },
-                {
-                    manager: 'kubectl',
-                    fieldsV1: {
-                        'f:metadata': {
-                            'f:labels': {}
-                        }
-                    }
-                }
-            ];
+	describe('isFieldManagedByManager', () => {
+		it('should correctly identify when a specific manager owns a field', () => {
+			const managedFields = [
+				{
+					manager: 'rollout-dashboard',
+					fieldsV1: {
+						'f:spec': {
+							'f:wantedVersion': {}
+						}
+					}
+				},
+				{
+					manager: 'kubectl',
+					fieldsV1: {
+						'f:metadata': {
+							'f:labels': {}
+						}
+					}
+				}
+			];
 
-            expect(isFieldManagedByManager(managedFields, 'rollout-dashboard', 'spec.wantedVersion')).toBe(true);
-            expect(isFieldManagedByManager(managedFields, 'kubectl', 'metadata.labels')).toBe(true);
-            expect(isFieldManagedByManager(managedFields, 'rollout-dashboard', 'metadata.labels')).toBe(false);
-            expect(isFieldManagedByManager(managedFields, 'kubectl', 'spec.wantedVersion')).toBe(false);
-        });
+			expect(
+				isFieldManagedByManager(managedFields, 'rollout-dashboard', 'spec.wantedVersion')
+			).toBe(true);
+			expect(isFieldManagedByManager(managedFields, 'kubectl', 'metadata.labels')).toBe(true);
+			expect(isFieldManagedByManager(managedFields, 'rollout-dashboard', 'metadata.labels')).toBe(
+				false
+			);
+			expect(isFieldManagedByManager(managedFields, 'kubectl', 'spec.wantedVersion')).toBe(false);
+		});
 
-        it('should handle empty or undefined managedFields', () => {
-            expect(isFieldManagedByManager([], 'rollout-dashboard', 'spec.wantedVersion')).toBe(false);
-            expect(isFieldManagedByManager(undefined as any, 'rollout-dashboard', 'spec.wantedVersion')).toBe(false);
-        });
+		it('should handle empty or undefined managedFields', () => {
+			expect(isFieldManagedByManager([], 'rollout-dashboard', 'spec.wantedVersion')).toBe(false);
+			expect(
+				isFieldManagedByManager(undefined as any, 'rollout-dashboard', 'spec.wantedVersion')
+			).toBe(false);
+		});
 
-        it('should handle fields without fieldsV1', () => {
-            const managedFields = [
-                {
-                    manager: 'rollout-dashboard',
-                    fieldsV1: undefined
-                }
-            ];
+		it('should handle fields without fieldsV1', () => {
+			const managedFields = [
+				{
+					manager: 'rollout-dashboard',
+					fieldsV1: undefined
+				}
+			];
 
-            expect(isFieldManagedByManager(managedFields, 'rollout-dashboard', 'spec.wantedVersion')).toBe(false);
-        });
-    });
+			expect(
+				isFieldManagedByManager(managedFields, 'rollout-dashboard', 'spec.wantedVersion')
+			).toBe(false);
+		});
+	});
 
-    describe('isFieldManagedByOtherManager', () => {
-        it('should correctly identify when other managers own a field', () => {
-            const managedFields = [
-                {
-                    manager: 'rollout-dashboard',
-                    fieldsV1: {
-                        'f:metadata': {
-                            'f:annotations': {}
-                        }
-                    }
-                },
-                {
-                    manager: 'kubectl',
-                    fieldsV1: {
-                        'f:spec': {
-                            'f:wantedVersion': {}
-                        }
-                    }
-                }
-            ];
+	describe('isFieldManagedByOtherManager', () => {
+		it('should correctly identify when other managers own a field', () => {
+			const managedFields = [
+				{
+					manager: 'rollout-dashboard',
+					fieldsV1: {
+						'f:metadata': {
+							'f:annotations': {}
+						}
+					}
+				},
+				{
+					manager: 'kubectl',
+					fieldsV1: {
+						'f:spec': {
+							'f:wantedVersion': {}
+						}
+					}
+				}
+			];
 
-            expect(isFieldManagedByOtherManager(managedFields, 'rollout-dashboard', 'spec.wantedVersion')).toBe(true);
-            expect(isFieldManagedByOtherManager(managedFields, 'rollout-dashboard', 'metadata.annotations')).toBe(false);
-            expect(isFieldManagedByOtherManager(managedFields, 'kubectl', 'spec.wantedVersion')).toBe(false);
-        });
+			expect(
+				isFieldManagedByOtherManager(managedFields, 'rollout-dashboard', 'spec.wantedVersion')
+			).toBe(true);
+			expect(
+				isFieldManagedByOtherManager(managedFields, 'rollout-dashboard', 'metadata.annotations')
+			).toBe(false);
+			expect(isFieldManagedByOtherManager(managedFields, 'kubectl', 'spec.wantedVersion')).toBe(
+				false
+			);
+		});
 
-        it('should ignore empty manager names', () => {
-            const managedFields = [
-                {
-                    manager: '',
-                    fieldsV1: {
-                        'f:spec': {
-                            'f:wantedVersion': {}
-                        }
-                    }
-                },
-                {
-                    manager: 'kubectl',
-                    fieldsV1: {
-                        'f:metadata': {
-                            'f:labels': {}
-                        }
-                    }
-                }
-            ];
+		it('should ignore empty manager names', () => {
+			const managedFields = [
+				{
+					manager: '',
+					fieldsV1: {
+						'f:spec': {
+							'f:wantedVersion': {}
+						}
+					}
+				},
+				{
+					manager: 'kubectl',
+					fieldsV1: {
+						'f:metadata': {
+							'f:labels': {}
+						}
+					}
+				}
+			];
 
-            expect(isFieldManagedByOtherManager(managedFields, 'rollout-dashboard', 'spec.wantedVersion')).toBe(false);
-            expect(isFieldManagedByOtherManager(managedFields, 'rollout-dashboard', 'metadata.labels')).toBe(true);
-        });
+			expect(
+				isFieldManagedByOtherManager(managedFields, 'rollout-dashboard', 'spec.wantedVersion')
+			).toBe(false);
+			expect(
+				isFieldManagedByOtherManager(managedFields, 'rollout-dashboard', 'metadata.labels')
+			).toBe(true);
+		});
 
-        it('should handle empty or undefined managedFields', () => {
-            expect(isFieldManagedByOtherManager([], 'rollout-dashboard', 'spec.wantedVersion')).toBe(false);
-            expect(isFieldManagedByOtherManager(undefined as any, 'rollout-dashboard', 'spec.wantedVersion')).toBe(false);
-        });
-    });
+		it('should handle empty or undefined managedFields', () => {
+			expect(isFieldManagedByOtherManager([], 'rollout-dashboard', 'spec.wantedVersion')).toBe(
+				false
+			);
+			expect(
+				isFieldManagedByOtherManager(undefined as any, 'rollout-dashboard', 'spec.wantedVersion')
+			).toBe(false);
+		});
+	});
 
-    describe('Real-world examples', () => {
-        it('should handle the example from the attached file', () => {
-            // This is a real fieldsV1 example from the attached file
-            const fieldsV1 = {
-                'f:metadata': {
-                    'f:annotations': {
-                        '.': {},
-                        'f:dashboard.rollout.kuberik.com/description': {},
-                        'f:kubectl.kubernetes.io/last-applied-configuration': {}
-                    },
-                    'f:labels': {
-                        '.': {},
-                        'f:environment': {}
-                    }
-                },
-                'f:spec': {
-                    '.': {},
-                    'f:healthCheckSelector': {},
-                    'f:minBakeTime': {},
-                    'f:releasesImagePolicy': {},
-                    'f:versionHistoryLimit': {}
-                }
-            };
+	describe('Real-world examples', () => {
+		it('should handle the example from the attached file', () => {
+			// This is a real fieldsV1 example from the attached file
+			const fieldsV1 = {
+				'f:metadata': {
+					'f:annotations': {
+						'.': {},
+						'f:dashboard.rollout.kuberik.com/description': {},
+						'f:kubectl.kubernetes.io/last-applied-configuration': {}
+					},
+					'f:labels': {
+						'.': {},
+						'f:environment': {}
+					}
+				},
+				'f:spec': {
+					'.': {},
+					'f:healthCheckSelector': {},
+					'f:minBakeTime': {},
+					'f:releasesImagePolicy': {},
+					'f:versionHistoryLimit': {}
+				}
+			};
 
-            expect(isFieldManaged(fieldsV1, 'metadata.annotations')).toBe(true);
-            expect(isFieldManaged(fieldsV1, 'metadata.labels.environment')).toBe(true);
-            expect(isFieldManaged(fieldsV1, 'spec.healthCheckSelector')).toBe(true);
-            expect(isFieldManaged(fieldsV1, 'spec.wantedVersion')).toBe(false); // This field is not managed
-            expect(isFieldManaged(fieldsV1, 'spec.releasesImagePolicy')).toBe(true);
-        });
-    });
+			expect(isFieldManaged(fieldsV1, 'metadata.annotations')).toBe(true);
+			expect(isFieldManaged(fieldsV1, 'metadata.labels.environment')).toBe(true);
+			expect(isFieldManaged(fieldsV1, 'spec.healthCheckSelector')).toBe(true);
+			expect(isFieldManaged(fieldsV1, 'spec.wantedVersion')).toBe(false); // This field is not managed
+			expect(isFieldManaged(fieldsV1, 'spec.releasesImagePolicy')).toBe(true);
+		});
+	});
 });
 
 describe('parseLinkAnnotations', () => {
-    it('should return empty array for undefined annotations', () => {
-        expect(parseLinkAnnotations(undefined)).toEqual([]);
-    });
+	it('should return empty array for undefined annotations', () => {
+		expect(parseLinkAnnotations(undefined)).toEqual([]);
+	});
 
-    it('should return empty array for empty annotations', () => {
-        expect(parseLinkAnnotations({})).toEqual([]);
-    });
+	it('should return empty array for empty annotations', () => {
+		expect(parseLinkAnnotations({})).toEqual([]);
+	});
 
-    it('should return empty array when no annotations match the link prefix', () => {
-        const annotations = {
-            'kubectl.kubernetes.io/last-applied-configuration': '{}',
-            'rollout.kuberik.com/bypass-gates': 'v1.2.3'
-        };
-        expect(parseLinkAnnotations(annotations)).toEqual([]);
-    });
+	it('should return empty array when no annotations match the link prefix', () => {
+		const annotations = {
+			'kubectl.kubernetes.io/last-applied-configuration': '{}',
+			'rollout.kuberik.com/bypass-gates': 'v1.2.3'
+		};
+		expect(parseLinkAnnotations(annotations)).toEqual([]);
+	});
 
-    it('should extract a single link annotation', () => {
-        const annotations = {
-            'rollout.kuberik.com/link.Logs': 'https://example.com/logs'
-        };
-        expect(parseLinkAnnotations(annotations)).toEqual([
-            { label: 'Logs', url: 'https://example.com/logs' }
-        ]);
-    });
+	it('should extract a single link annotation', () => {
+		const annotations = {
+			'rollout.kuberik.com/link.Logs': 'https://example.com/logs'
+		};
+		expect(parseLinkAnnotations(annotations)).toEqual([
+			{ label: 'Logs', url: 'https://example.com/logs' }
+		]);
+	});
 
-    it('should extract multiple link annotations', () => {
-        const annotations = {
-            'rollout.kuberik.com/link.Logs': 'https://example.com/logs',
-            'rollout.kuberik.com/link.CI': 'https://example.com/ci'
-        };
-        const result = parseLinkAnnotations(annotations);
-        expect(result).toHaveLength(2);
-        expect(result).toContainEqual({ label: 'Logs', url: 'https://example.com/logs' });
-        expect(result).toContainEqual({ label: 'CI', url: 'https://example.com/ci' });
-    });
+	it('should extract multiple link annotations', () => {
+		const annotations = {
+			'rollout.kuberik.com/link.Logs': 'https://example.com/logs',
+			'rollout.kuberik.com/link.CI': 'https://example.com/ci'
+		};
+		const result = parseLinkAnnotations(annotations);
+		expect(result).toHaveLength(2);
+		expect(result).toContainEqual({ label: 'Logs', url: 'https://example.com/logs' });
+		expect(result).toContainEqual({ label: 'CI', url: 'https://example.com/ci' });
+	});
 
-    it('should ignore non-link annotations mixed in', () => {
-        const annotations = {
-            'kubectl.kubernetes.io/last-applied-configuration': '{}',
-            'rollout.kuberik.com/link.Logs': 'https://example.com/logs',
-            'rollout.kuberik.com/bypass-gates': 'v1.0.0',
-            'rollout.kuberik.com/link.CI': 'https://example.com/ci'
-        };
-        const result = parseLinkAnnotations(annotations);
-        expect(result).toHaveLength(2);
-        expect(result).toContainEqual({ label: 'Logs', url: 'https://example.com/logs' });
-        expect(result).toContainEqual({ label: 'CI', url: 'https://example.com/ci' });
-    });
+	it('should ignore non-link annotations mixed in', () => {
+		const annotations = {
+			'kubectl.kubernetes.io/last-applied-configuration': '{}',
+			'rollout.kuberik.com/link.Logs': 'https://example.com/logs',
+			'rollout.kuberik.com/bypass-gates': 'v1.0.0',
+			'rollout.kuberik.com/link.CI': 'https://example.com/ci'
+		};
+		const result = parseLinkAnnotations(annotations);
+		expect(result).toHaveLength(2);
+		expect(result).toContainEqual({ label: 'Logs', url: 'https://example.com/logs' });
+		expect(result).toContainEqual({ label: 'CI', url: 'https://example.com/ci' });
+	});
 
-    it('should preserve the full URL value including encoded characters', () => {
-        const annotations = {
-            'rollout.kuberik.com/link.CI': 'https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20-%40ci.provider.name%3Agithub%20%40test.service%3Amyservice%20%40version%3Av1.0.0'
-        };
-        const result = parseLinkAnnotations(annotations);
-        expect(result).toEqual([
-            {
-                label: 'CI',
-                url: 'https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20-%40ci.provider.name%3Agithub%20%40test.service%3Amyservice%20%40version%3Av1.0.0'
-            }
-        ]);
-    });
+	it('should preserve the full URL value including encoded characters', () => {
+		const annotations = {
+			'rollout.kuberik.com/link.CI':
+				'https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20-%40ci.provider.name%3Agithub%20%40test.service%3Amyservice%20%40version%3Av1.0.0'
+		};
+		const result = parseLinkAnnotations(annotations);
+		expect(result).toEqual([
+			{
+				label: 'CI',
+				url: 'https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20-%40ci.provider.name%3Agithub%20%40test.service%3Amyservice%20%40version%3Av1.0.0'
+			}
+		]);
+	});
+});
+
+describe('environment themes', () => {
+	it('returns null when a rollout has no theme annotations', () => {
+		expect(getRolloutEnvironmentTheme({ metadata: { annotations: {} } } as any)).toBeNull();
+		expect(getRolloutEnvironmentTheme(null)).toBeNull();
+	});
+
+	it('maps production to a non-red preset theme', () => {
+		const theme = getRolloutEnvironmentTheme({
+			metadata: {
+				annotations: {
+					[ENVIRONMENT_THEME_ANNOTATION]: 'prod'
+				}
+			}
+		} as any);
+
+		expect(theme?.label).toBe('Production');
+		expect(theme?.color).toBe('#d97706');
+		expect(theme?.color).not.toMatch(/^#(?:dc2626|ef4444|f87171)$/);
+	});
+
+	it('maps development to the green preset theme', () => {
+		const theme = getRolloutEnvironmentTheme({
+			metadata: {
+				annotations: {
+					[ENVIRONMENT_THEME_ANNOTATION]: 'development'
+				}
+			}
+		} as any);
+
+		expect(theme?.label).toBe('Development');
+		expect(theme?.color).toBe('#16a34a');
+	});
+
+	it('uses a custom hex color annotation with an optional label', () => {
+		const theme = getRolloutEnvironmentTheme({
+			metadata: {
+				annotations: {
+					[ENVIRONMENT_THEME_COLOR_ANNOTATION]: '#0EA5E9',
+					[ENVIRONMENT_THEME_LABEL_ANNOTATION]: 'Sandbox'
+				}
+			}
+		} as any);
+
+		expect(theme?.label).toBe('Sandbox');
+		expect(theme?.color).toBe('#0ea5e9');
+	});
+
+	it('rejects invalid custom color values', () => {
+		const theme = getRolloutEnvironmentTheme({
+			metadata: {
+				annotations: {
+					[ENVIRONMENT_THEME_COLOR_ANNOTATION]: 'url(https://example.com/image.png)'
+				}
+			}
+		} as any);
+
+		expect(theme).toBeNull();
+	});
+
+	it('returns CSS variables for a parsed theme', () => {
+		const theme = getRolloutEnvironmentTheme({
+			metadata: {
+				annotations: {
+					[ENVIRONMENT_THEME_ANNOTATION]: 'staging'
+				}
+			}
+		} as any);
+
+		expect(theme).not.toBeNull();
+		expect(getEnvironmentThemeStyle(theme!)).toContain('--rollout-theme-accent: #7c3aed');
+	});
 });
 
 describe('extractDatadogInfoFromContainers', () => {
-    it('should return null for empty containers array', () => {
-        expect(extractDatadogInfoFromContainers([])).toBeNull();
-    });
+	it('should return null for empty containers array', () => {
+		expect(extractDatadogInfoFromContainers([])).toBeNull();
+	});
 
-    it('should return null when no DD env vars are present', () => {
-        const containers = [{ env: [{ name: 'FOO', value: 'bar' }] }];
-        expect(extractDatadogInfoFromContainers(containers)).toBeNull();
-    });
+	it('should return null when no DD env vars are present', () => {
+		const containers = [{ env: [{ name: 'FOO', value: 'bar' }] }];
+		expect(extractDatadogInfoFromContainers(containers)).toBeNull();
+	});
 
-    it('should return null when only DD_SERVICE is present', () => {
-        const containers = [{ env: [{ name: 'DD_SERVICE', value: 'my-service' }] }];
-        expect(extractDatadogInfoFromContainers(containers)).toBeNull();
-    });
+	it('should return null when only DD_SERVICE is present', () => {
+		const containers = [{ env: [{ name: 'DD_SERVICE', value: 'my-service' }] }];
+		expect(extractDatadogInfoFromContainers(containers)).toBeNull();
+	});
 
-    it('should return null when only DD_ENV is present', () => {
-        const containers = [{ env: [{ name: 'DD_ENV', value: 'dev' }] }];
-        expect(extractDatadogInfoFromContainers(containers)).toBeNull();
-    });
+	it('should return null when only DD_ENV is present', () => {
+		const containers = [{ env: [{ name: 'DD_ENV', value: 'dev' }] }];
+		expect(extractDatadogInfoFromContainers(containers)).toBeNull();
+	});
 
-    it('should extract service and env when both are present', () => {
-        const containers = [{
-            env: [
-                { name: 'DD_SERVICE', value: 'my-service' },
-                { name: 'DD_ENV', value: 'production' }
-            ]
-        }];
-        expect(extractDatadogInfoFromContainers(containers)).toEqual({
-            service: 'my-service',
-            env: 'production'
-        });
-    });
+	it('should extract service and env when both are present', () => {
+		const containers = [
+			{
+				env: [
+					{ name: 'DD_SERVICE', value: 'my-service' },
+					{ name: 'DD_ENV', value: 'production' }
+				]
+			}
+		];
+		expect(extractDatadogInfoFromContainers(containers)).toEqual({
+			service: 'my-service',
+			env: 'production'
+		});
+	});
 
-    it('should extract service, env and version when all are present', () => {
-        const containers = [{
-            env: [
-                { name: 'DD_SERVICE', value: 'my-service' },
-                { name: 'DD_ENV', value: 'production' },
-                { name: 'DD_VERSION', value: 'main-1770831919-d4cd2de3ed1185943c9105df735a099a2165c7ce' }
-            ]
-        }];
-        expect(extractDatadogInfoFromContainers(containers)).toEqual({
-            service: 'my-service',
-            env: 'production',
-            version: 'main-1770831919-d4cd2de3ed1185943c9105df735a099a2165c7ce'
-        });
-    });
+	it('should extract service, env and version when all are present', () => {
+		const containers = [
+			{
+				env: [
+					{ name: 'DD_SERVICE', value: 'my-service' },
+					{ name: 'DD_ENV', value: 'production' },
+					{ name: 'DD_VERSION', value: 'main-1770831919-d4cd2de3ed1185943c9105df735a099a2165c7ce' }
+				]
+			}
+		];
+		expect(extractDatadogInfoFromContainers(containers)).toEqual({
+			service: 'my-service',
+			env: 'production',
+			version: 'main-1770831919-d4cd2de3ed1185943c9105df735a099a2165c7ce'
+		});
+	});
 
-    it('should return info without version when DD_VERSION is absent', () => {
-        const containers = [{
-            env: [
-                { name: 'DD_SERVICE', value: 'my-service' },
-                { name: 'DD_ENV', value: 'staging' }
-            ]
-        }];
-        const result = extractDatadogInfoFromContainers(containers);
-        expect(result).toEqual({ service: 'my-service', env: 'staging' });
-        expect(result?.version).toBeUndefined();
-    });
+	it('should return info without version when DD_VERSION is absent', () => {
+		const containers = [
+			{
+				env: [
+					{ name: 'DD_SERVICE', value: 'my-service' },
+					{ name: 'DD_ENV', value: 'staging' }
+				]
+			}
+		];
+		const result = extractDatadogInfoFromContainers(containers);
+		expect(result).toEqual({ service: 'my-service', env: 'staging' });
+		expect(result?.version).toBeUndefined();
+	});
 
-    it('should find DD tags in a second container if first has none', () => {
-        const containers = [
-            { env: [{ name: 'FOO', value: 'bar' }] },
-            {
-                env: [
-                    { name: 'DD_SERVICE', value: 'backend' },
-                    { name: 'DD_ENV', value: 'staging' }
-                ]
-            }
-        ];
-        expect(extractDatadogInfoFromContainers(containers)).toEqual({
-            service: 'backend',
-            env: 'staging'
-        });
-    });
+	it('should find DD tags in a second container if first has none', () => {
+		const containers = [
+			{ env: [{ name: 'FOO', value: 'bar' }] },
+			{
+				env: [
+					{ name: 'DD_SERVICE', value: 'backend' },
+					{ name: 'DD_ENV', value: 'staging' }
+				]
+			}
+		];
+		expect(extractDatadogInfoFromContainers(containers)).toEqual({
+			service: 'backend',
+			env: 'staging'
+		});
+	});
 
-    it('should handle containers with no env field', () => {
-        const containers = [{}];
-        expect(extractDatadogInfoFromContainers(containers)).toBeNull();
-    });
+	it('should handle containers with no env field', () => {
+		const containers = [{}];
+		expect(extractDatadogInfoFromContainers(containers)).toBeNull();
+	});
 
-    it('should ignore env vars with empty values', () => {
-        const containers = [{
-            env: [
-                { name: 'DD_SERVICE', value: '' },
-                { name: 'DD_ENV', value: 'dev' }
-            ]
-        }];
-        expect(extractDatadogInfoFromContainers(containers)).toBeNull();
-    });
+	it('should ignore env vars with empty values', () => {
+		const containers = [
+			{
+				env: [
+					{ name: 'DD_SERVICE', value: '' },
+					{ name: 'DD_ENV', value: 'dev' }
+				]
+			}
+		];
+		expect(extractDatadogInfoFromContainers(containers)).toBeNull();
+	});
 });
 
 describe('buildDatadogTestRunsUrl', () => {
-    it('should build a URL with service and version', () => {
-        const url = buildDatadogTestRunsUrl('my-service', 'v1.0.0');
-        expect(url).toContain('https://app.datadoghq.com/ci/test/runs?query=');
-        expect(url).toContain(encodeURIComponent('@test.service:my-service'));
-        expect(url).toContain(encodeURIComponent('@version:v1.0.0'));
-    });
+	it('should build a URL with service and version', () => {
+		const url = buildDatadogTestRunsUrl('my-service', 'v1.0.0');
+		expect(url).toContain('https://app.datadoghq.com/ci/test/runs?query=');
+		expect(url).toContain(encodeURIComponent('@test.service:my-service'));
+		expect(url).toContain(encodeURIComponent('@version:v1.0.0'));
+	});
 });
 
 describe('buildDatadogLogsUrl', () => {
-    it('should build a URL with service and env', () => {
-        const url = buildDatadogLogsUrl('my-service', 'production');
-        expect(url).toContain('https://app.datadoghq.com/logs?query=');
-        expect(url).toContain(encodeURIComponent('service:my-service'));
-        expect(url).toContain(encodeURIComponent('env:production'));
-        expect(url).toContain('&live=true');
-    });
+	it('should build a URL with service and env', () => {
+		const url = buildDatadogLogsUrl('my-service', 'production');
+		expect(url).toContain('https://app.datadoghq.com/logs?query=');
+		expect(url).toContain(encodeURIComponent('service:my-service'));
+		expect(url).toContain(encodeURIComponent('env:production'));
+		expect(url).toContain('&live=true');
+	});
 });
 
 describe('buildDatadogTraceSearchUrl', () => {
-    it('should build a URL with service, env, and version', () => {
-        const url = buildDatadogTraceSearchUrl('my-service', 'production', 'v1.0.0');
-        expect(url).toContain('https://app.datadoghq.com/apm/traces?query=');
-        expect(url).toContain(encodeURIComponent('service:my-service'));
-        expect(url).toContain(encodeURIComponent('env:production'));
-        expect(url).toContain(encodeURIComponent('version:v1.0.0'));
-        // `@rollout.test:true` marker is what distinguishes rollout-test
-        // traces from the service Deployment's regular APM traffic; without
-        // it the search would also surface unrelated traffic.
-        expect(url).toContain(encodeURIComponent('@rollout.test:true'));
-    });
+	it('should build a URL with service, env, and version', () => {
+		const url = buildDatadogTraceSearchUrl('my-service', 'production', 'v1.0.0');
+		expect(url).toContain('https://app.datadoghq.com/apm/traces?query=');
+		expect(url).toContain(encodeURIComponent('service:my-service'));
+		expect(url).toContain(encodeURIComponent('env:production'));
+		expect(url).toContain(encodeURIComponent('version:v1.0.0'));
+		// `@rollout.test:true` marker is what distinguishes rollout-test
+		// traces from the service Deployment's regular APM traffic; without
+		// it the search would also surface unrelated traffic.
+		expect(url).toContain(encodeURIComponent('@rollout.test:true'));
+	});
 
-    it('should omit the version filter when no version is provided', () => {
-        const url = buildDatadogTraceSearchUrl('my-service', 'staging');
-        expect(url).toContain('https://app.datadoghq.com/apm/traces?query=');
-        expect(url).toContain(encodeURIComponent('service:my-service'));
-        expect(url).toContain(encodeURIComponent('env:staging'));
-        expect(url).toContain(encodeURIComponent('@rollout.test:true'));
-        expect(url).not.toContain(encodeURIComponent('version:'));
-    });
+	it('should omit the version filter when no version is provided', () => {
+		const url = buildDatadogTraceSearchUrl('my-service', 'staging');
+		expect(url).toContain('https://app.datadoghq.com/apm/traces?query=');
+		expect(url).toContain(encodeURIComponent('service:my-service'));
+		expect(url).toContain(encodeURIComponent('env:staging'));
+		expect(url).toContain(encodeURIComponent('@rollout.test:true'));
+		expect(url).not.toContain(encodeURIComponent('version:'));
+	});
 });

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -1,493 +1,453 @@
 import { describe, it, expect } from 'vitest';
+import { isFieldManaged, isFieldManagedByManager, isFieldManagedByOtherManager, parseLinkAnnotations, extractDatadogInfoFromContainers, buildDatadogTestRunsUrl, buildDatadogLogsUrl, buildDatadogTraceSearchUrl } from './utils';
 import {
-	isFieldManaged,
-	isFieldManagedByManager,
-	isFieldManagedByOtherManager,
-	parseLinkAnnotations,
-	extractDatadogInfoFromContainers,
-	buildDatadogTestRunsUrl,
-	buildDatadogLogsUrl,
-	buildDatadogTraceSearchUrl
-} from './utils';
-import {
-	ENVIRONMENT_THEME_ANNOTATION,
-	ENVIRONMENT_THEME_COLOR_ANNOTATION,
-	ENVIRONMENT_THEME_LABEL_ANNOTATION,
-	getEnvironmentThemeStyle,
-	getRolloutEnvironmentTheme
+    ENVIRONMENT_THEME_ANNOTATION,
+    ENVIRONMENT_THEME_COLOR_ANNOTATION,
+    ENVIRONMENT_THEME_LABEL_ANNOTATION,
+    getEnvironmentThemeStyle,
+    getRolloutEnvironmentTheme
 } from './environment-theme';
 
 describe('Field Manager Validation', () => {
-	describe('isFieldManaged', () => {
-		it('should correctly parse fieldsV1 YAML structure and validate field paths', () => {
-			// Example fieldsV1 from a real Kubernetes resource
-			const fieldsV1 = {
-				'f:spec': {
-					'f:wantedVersion': {}
-				}
-			};
+    describe('isFieldManaged', () => {
+        it('should correctly parse fieldsV1 YAML structure and validate field paths', () => {
+            // Example fieldsV1 from a real Kubernetes resource
+            const fieldsV1 = {
+                'f:spec': {
+                    'f:wantedVersion': {}
+                }
+            };
 
-			expect(isFieldManaged(fieldsV1, 'spec.wantedVersion')).toBe(true);
-			expect(isFieldManaged(fieldsV1, 'spec')).toBe(true);
-			expect(isFieldManaged(fieldsV1, 'metadata.name')).toBe(false);
-			expect(isFieldManaged(fieldsV1, 'spec.otherField')).toBe(false);
-		});
+            expect(isFieldManaged(fieldsV1, 'spec.wantedVersion')).toBe(true);
+            expect(isFieldManaged(fieldsV1, 'spec')).toBe(true);
+            expect(isFieldManaged(fieldsV1, 'metadata.name')).toBe(false);
+            expect(isFieldManaged(fieldsV1, 'spec.otherField')).toBe(false);
+        });
 
-		it('should handle nested field paths correctly', () => {
-			const fieldsV1 = {
-				'f:spec': {
-					'f:healthCheckSelector': {
-						'f:matchLabels': {
-							'f:app': {}
-						}
-					}
-				}
-			};
+        it('should handle nested field paths correctly', () => {
+            const fieldsV1 = {
+                'f:spec': {
+                    'f:healthCheckSelector': {
+                        'f:matchLabels': {
+                            'f:app': {}
+                        }
+                    }
+                }
+            };
 
-			expect(isFieldManaged(fieldsV1, 'spec.healthCheckSelector.matchLabels.app')).toBe(true);
-			expect(isFieldManaged(fieldsV1, 'spec.healthCheckSelector')).toBe(true);
-			expect(isFieldManaged(fieldsV1, 'spec.healthCheckSelector.matchLabels')).toBe(true);
-			expect(isFieldManaged(fieldsV1, 'spec.healthCheckSelector.matchLabels.other')).toBe(false);
-		});
+            expect(isFieldManaged(fieldsV1, 'spec.healthCheckSelector.matchLabels.app')).toBe(true);
+            expect(isFieldManaged(fieldsV1, 'spec.healthCheckSelector')).toBe(true);
+            expect(isFieldManaged(fieldsV1, 'spec.healthCheckSelector.matchLabels')).toBe(true);
+            expect(isFieldManaged(fieldsV1, 'spec.healthCheckSelector.matchLabels.other')).toBe(false);
+        });
 
-		it('should handle empty or undefined fieldsV1', () => {
-			expect(isFieldManaged('', 'spec.wantedVersion')).toBe(false);
-			expect(isFieldManaged({}, 'spec.wantedVersion')).toBe(false);
-			expect(isFieldManaged(undefined, 'spec.wantedVersion')).toBe(false);
-		});
-	});
+        it('should handle empty or undefined fieldsV1', () => {
+            expect(isFieldManaged('', 'spec.wantedVersion')).toBe(false);
+            expect(isFieldManaged({}, 'spec.wantedVersion')).toBe(false);
+            expect(isFieldManaged(undefined, 'spec.wantedVersion')).toBe(false);
+        });
+    });
 
-	describe('isFieldManagedByManager', () => {
-		it('should correctly identify when a specific manager owns a field', () => {
-			const managedFields = [
-				{
-					manager: 'rollout-dashboard',
-					fieldsV1: {
-						'f:spec': {
-							'f:wantedVersion': {}
-						}
-					}
-				},
-				{
-					manager: 'kubectl',
-					fieldsV1: {
-						'f:metadata': {
-							'f:labels': {}
-						}
-					}
-				}
-			];
+    describe('isFieldManagedByManager', () => {
+        it('should correctly identify when a specific manager owns a field', () => {
+            const managedFields = [
+                {
+                    manager: 'rollout-dashboard',
+                    fieldsV1: {
+                        'f:spec': {
+                            'f:wantedVersion': {}
+                        }
+                    }
+                },
+                {
+                    manager: 'kubectl',
+                    fieldsV1: {
+                        'f:metadata': {
+                            'f:labels': {}
+                        }
+                    }
+                }
+            ];
 
-			expect(
-				isFieldManagedByManager(managedFields, 'rollout-dashboard', 'spec.wantedVersion')
-			).toBe(true);
-			expect(isFieldManagedByManager(managedFields, 'kubectl', 'metadata.labels')).toBe(true);
-			expect(isFieldManagedByManager(managedFields, 'rollout-dashboard', 'metadata.labels')).toBe(
-				false
-			);
-			expect(isFieldManagedByManager(managedFields, 'kubectl', 'spec.wantedVersion')).toBe(false);
-		});
+            expect(isFieldManagedByManager(managedFields, 'rollout-dashboard', 'spec.wantedVersion')).toBe(true);
+            expect(isFieldManagedByManager(managedFields, 'kubectl', 'metadata.labels')).toBe(true);
+            expect(isFieldManagedByManager(managedFields, 'rollout-dashboard', 'metadata.labels')).toBe(false);
+            expect(isFieldManagedByManager(managedFields, 'kubectl', 'spec.wantedVersion')).toBe(false);
+        });
 
-		it('should handle empty or undefined managedFields', () => {
-			expect(isFieldManagedByManager([], 'rollout-dashboard', 'spec.wantedVersion')).toBe(false);
-			expect(
-				isFieldManagedByManager(undefined as any, 'rollout-dashboard', 'spec.wantedVersion')
-			).toBe(false);
-		});
+        it('should handle empty or undefined managedFields', () => {
+            expect(isFieldManagedByManager([], 'rollout-dashboard', 'spec.wantedVersion')).toBe(false);
+            expect(isFieldManagedByManager(undefined as any, 'rollout-dashboard', 'spec.wantedVersion')).toBe(false);
+        });
 
-		it('should handle fields without fieldsV1', () => {
-			const managedFields = [
-				{
-					manager: 'rollout-dashboard',
-					fieldsV1: undefined
-				}
-			];
+        it('should handle fields without fieldsV1', () => {
+            const managedFields = [
+                {
+                    manager: 'rollout-dashboard',
+                    fieldsV1: undefined
+                }
+            ];
 
-			expect(
-				isFieldManagedByManager(managedFields, 'rollout-dashboard', 'spec.wantedVersion')
-			).toBe(false);
-		});
-	});
+            expect(isFieldManagedByManager(managedFields, 'rollout-dashboard', 'spec.wantedVersion')).toBe(false);
+        });
+    });
 
-	describe('isFieldManagedByOtherManager', () => {
-		it('should correctly identify when other managers own a field', () => {
-			const managedFields = [
-				{
-					manager: 'rollout-dashboard',
-					fieldsV1: {
-						'f:metadata': {
-							'f:annotations': {}
-						}
-					}
-				},
-				{
-					manager: 'kubectl',
-					fieldsV1: {
-						'f:spec': {
-							'f:wantedVersion': {}
-						}
-					}
-				}
-			];
+    describe('isFieldManagedByOtherManager', () => {
+        it('should correctly identify when other managers own a field', () => {
+            const managedFields = [
+                {
+                    manager: 'rollout-dashboard',
+                    fieldsV1: {
+                        'f:metadata': {
+                            'f:annotations': {}
+                        }
+                    }
+                },
+                {
+                    manager: 'kubectl',
+                    fieldsV1: {
+                        'f:spec': {
+                            'f:wantedVersion': {}
+                        }
+                    }
+                }
+            ];
 
-			expect(
-				isFieldManagedByOtherManager(managedFields, 'rollout-dashboard', 'spec.wantedVersion')
-			).toBe(true);
-			expect(
-				isFieldManagedByOtherManager(managedFields, 'rollout-dashboard', 'metadata.annotations')
-			).toBe(false);
-			expect(isFieldManagedByOtherManager(managedFields, 'kubectl', 'spec.wantedVersion')).toBe(
-				false
-			);
-		});
+            expect(isFieldManagedByOtherManager(managedFields, 'rollout-dashboard', 'spec.wantedVersion')).toBe(true);
+            expect(isFieldManagedByOtherManager(managedFields, 'rollout-dashboard', 'metadata.annotations')).toBe(false);
+            expect(isFieldManagedByOtherManager(managedFields, 'kubectl', 'spec.wantedVersion')).toBe(false);
+        });
 
-		it('should ignore empty manager names', () => {
-			const managedFields = [
-				{
-					manager: '',
-					fieldsV1: {
-						'f:spec': {
-							'f:wantedVersion': {}
-						}
-					}
-				},
-				{
-					manager: 'kubectl',
-					fieldsV1: {
-						'f:metadata': {
-							'f:labels': {}
-						}
-					}
-				}
-			];
+        it('should ignore empty manager names', () => {
+            const managedFields = [
+                {
+                    manager: '',
+                    fieldsV1: {
+                        'f:spec': {
+                            'f:wantedVersion': {}
+                        }
+                    }
+                },
+                {
+                    manager: 'kubectl',
+                    fieldsV1: {
+                        'f:metadata': {
+                            'f:labels': {}
+                        }
+                    }
+                }
+            ];
 
-			expect(
-				isFieldManagedByOtherManager(managedFields, 'rollout-dashboard', 'spec.wantedVersion')
-			).toBe(false);
-			expect(
-				isFieldManagedByOtherManager(managedFields, 'rollout-dashboard', 'metadata.labels')
-			).toBe(true);
-		});
+            expect(isFieldManagedByOtherManager(managedFields, 'rollout-dashboard', 'spec.wantedVersion')).toBe(false);
+            expect(isFieldManagedByOtherManager(managedFields, 'rollout-dashboard', 'metadata.labels')).toBe(true);
+        });
 
-		it('should handle empty or undefined managedFields', () => {
-			expect(isFieldManagedByOtherManager([], 'rollout-dashboard', 'spec.wantedVersion')).toBe(
-				false
-			);
-			expect(
-				isFieldManagedByOtherManager(undefined as any, 'rollout-dashboard', 'spec.wantedVersion')
-			).toBe(false);
-		});
-	});
+        it('should handle empty or undefined managedFields', () => {
+            expect(isFieldManagedByOtherManager([], 'rollout-dashboard', 'spec.wantedVersion')).toBe(false);
+            expect(isFieldManagedByOtherManager(undefined as any, 'rollout-dashboard', 'spec.wantedVersion')).toBe(false);
+        });
+    });
 
-	describe('Real-world examples', () => {
-		it('should handle the example from the attached file', () => {
-			// This is a real fieldsV1 example from the attached file
-			const fieldsV1 = {
-				'f:metadata': {
-					'f:annotations': {
-						'.': {},
-						'f:dashboard.rollout.kuberik.com/description': {},
-						'f:kubectl.kubernetes.io/last-applied-configuration': {}
-					},
-					'f:labels': {
-						'.': {},
-						'f:environment': {}
-					}
-				},
-				'f:spec': {
-					'.': {},
-					'f:healthCheckSelector': {},
-					'f:minBakeTime': {},
-					'f:releasesImagePolicy': {},
-					'f:versionHistoryLimit': {}
-				}
-			};
+    describe('Real-world examples', () => {
+        it('should handle the example from the attached file', () => {
+            // This is a real fieldsV1 example from the attached file
+            const fieldsV1 = {
+                'f:metadata': {
+                    'f:annotations': {
+                        '.': {},
+                        'f:dashboard.rollout.kuberik.com/description': {},
+                        'f:kubectl.kubernetes.io/last-applied-configuration': {}
+                    },
+                    'f:labels': {
+                        '.': {},
+                        'f:environment': {}
+                    }
+                },
+                'f:spec': {
+                    '.': {},
+                    'f:healthCheckSelector': {},
+                    'f:minBakeTime': {},
+                    'f:releasesImagePolicy': {},
+                    'f:versionHistoryLimit': {}
+                }
+            };
 
-			expect(isFieldManaged(fieldsV1, 'metadata.annotations')).toBe(true);
-			expect(isFieldManaged(fieldsV1, 'metadata.labels.environment')).toBe(true);
-			expect(isFieldManaged(fieldsV1, 'spec.healthCheckSelector')).toBe(true);
-			expect(isFieldManaged(fieldsV1, 'spec.wantedVersion')).toBe(false); // This field is not managed
-			expect(isFieldManaged(fieldsV1, 'spec.releasesImagePolicy')).toBe(true);
-		});
-	});
+            expect(isFieldManaged(fieldsV1, 'metadata.annotations')).toBe(true);
+            expect(isFieldManaged(fieldsV1, 'metadata.labels.environment')).toBe(true);
+            expect(isFieldManaged(fieldsV1, 'spec.healthCheckSelector')).toBe(true);
+            expect(isFieldManaged(fieldsV1, 'spec.wantedVersion')).toBe(false); // This field is not managed
+            expect(isFieldManaged(fieldsV1, 'spec.releasesImagePolicy')).toBe(true);
+        });
+    });
 });
 
 describe('parseLinkAnnotations', () => {
-	it('should return empty array for undefined annotations', () => {
-		expect(parseLinkAnnotations(undefined)).toEqual([]);
-	});
+    it('should return empty array for undefined annotations', () => {
+        expect(parseLinkAnnotations(undefined)).toEqual([]);
+    });
 
-	it('should return empty array for empty annotations', () => {
-		expect(parseLinkAnnotations({})).toEqual([]);
-	});
+    it('should return empty array for empty annotations', () => {
+        expect(parseLinkAnnotations({})).toEqual([]);
+    });
 
-	it('should return empty array when no annotations match the link prefix', () => {
-		const annotations = {
-			'kubectl.kubernetes.io/last-applied-configuration': '{}',
-			'rollout.kuberik.com/bypass-gates': 'v1.2.3'
-		};
-		expect(parseLinkAnnotations(annotations)).toEqual([]);
-	});
+    it('should return empty array when no annotations match the link prefix', () => {
+        const annotations = {
+            'kubectl.kubernetes.io/last-applied-configuration': '{}',
+            'rollout.kuberik.com/bypass-gates': 'v1.2.3'
+        };
+        expect(parseLinkAnnotations(annotations)).toEqual([]);
+    });
 
-	it('should extract a single link annotation', () => {
-		const annotations = {
-			'rollout.kuberik.com/link.Logs': 'https://example.com/logs'
-		};
-		expect(parseLinkAnnotations(annotations)).toEqual([
-			{ label: 'Logs', url: 'https://example.com/logs' }
-		]);
-	});
+    it('should extract a single link annotation', () => {
+        const annotations = {
+            'rollout.kuberik.com/link.Logs': 'https://example.com/logs'
+        };
+        expect(parseLinkAnnotations(annotations)).toEqual([
+            { label: 'Logs', url: 'https://example.com/logs' }
+        ]);
+    });
 
-	it('should extract multiple link annotations', () => {
-		const annotations = {
-			'rollout.kuberik.com/link.Logs': 'https://example.com/logs',
-			'rollout.kuberik.com/link.CI': 'https://example.com/ci'
-		};
-		const result = parseLinkAnnotations(annotations);
-		expect(result).toHaveLength(2);
-		expect(result).toContainEqual({ label: 'Logs', url: 'https://example.com/logs' });
-		expect(result).toContainEqual({ label: 'CI', url: 'https://example.com/ci' });
-	});
+    it('should extract multiple link annotations', () => {
+        const annotations = {
+            'rollout.kuberik.com/link.Logs': 'https://example.com/logs',
+            'rollout.kuberik.com/link.CI': 'https://example.com/ci'
+        };
+        const result = parseLinkAnnotations(annotations);
+        expect(result).toHaveLength(2);
+        expect(result).toContainEqual({ label: 'Logs', url: 'https://example.com/logs' });
+        expect(result).toContainEqual({ label: 'CI', url: 'https://example.com/ci' });
+    });
 
-	it('should ignore non-link annotations mixed in', () => {
-		const annotations = {
-			'kubectl.kubernetes.io/last-applied-configuration': '{}',
-			'rollout.kuberik.com/link.Logs': 'https://example.com/logs',
-			'rollout.kuberik.com/bypass-gates': 'v1.0.0',
-			'rollout.kuberik.com/link.CI': 'https://example.com/ci'
-		};
-		const result = parseLinkAnnotations(annotations);
-		expect(result).toHaveLength(2);
-		expect(result).toContainEqual({ label: 'Logs', url: 'https://example.com/logs' });
-		expect(result).toContainEqual({ label: 'CI', url: 'https://example.com/ci' });
-	});
+    it('should ignore non-link annotations mixed in', () => {
+        const annotations = {
+            'kubectl.kubernetes.io/last-applied-configuration': '{}',
+            'rollout.kuberik.com/link.Logs': 'https://example.com/logs',
+            'rollout.kuberik.com/bypass-gates': 'v1.0.0',
+            'rollout.kuberik.com/link.CI': 'https://example.com/ci'
+        };
+        const result = parseLinkAnnotations(annotations);
+        expect(result).toHaveLength(2);
+        expect(result).toContainEqual({ label: 'Logs', url: 'https://example.com/logs' });
+        expect(result).toContainEqual({ label: 'CI', url: 'https://example.com/ci' });
+    });
 
-	it('should preserve the full URL value including encoded characters', () => {
-		const annotations = {
-			'rollout.kuberik.com/link.CI':
-				'https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20-%40ci.provider.name%3Agithub%20%40test.service%3Amyservice%20%40version%3Av1.0.0'
-		};
-		const result = parseLinkAnnotations(annotations);
-		expect(result).toEqual([
-			{
-				label: 'CI',
-				url: 'https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20-%40ci.provider.name%3Agithub%20%40test.service%3Amyservice%20%40version%3Av1.0.0'
-			}
-		]);
-	});
+    it('should preserve the full URL value including encoded characters', () => {
+        const annotations = {
+            'rollout.kuberik.com/link.CI': 'https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20-%40ci.provider.name%3Agithub%20%40test.service%3Amyservice%20%40version%3Av1.0.0'
+        };
+        const result = parseLinkAnnotations(annotations);
+        expect(result).toEqual([
+            {
+                label: 'CI',
+                url: 'https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20-%40ci.provider.name%3Agithub%20%40test.service%3Amyservice%20%40version%3Av1.0.0'
+            }
+        ]);
+    });
 });
 
 describe('environment themes', () => {
-	it('returns null when a rollout has no theme annotations', () => {
-		expect(getRolloutEnvironmentTheme({ metadata: { annotations: {} } } as any)).toBeNull();
-		expect(getRolloutEnvironmentTheme(null)).toBeNull();
-	});
+    it('returns null when a rollout has no theme annotations', () => {
+        expect(getRolloutEnvironmentTheme({ metadata: { annotations: {} } } as any)).toBeNull();
+        expect(getRolloutEnvironmentTheme(null)).toBeNull();
+    });
 
-	it('maps production to a non-red preset theme', () => {
-		const theme = getRolloutEnvironmentTheme({
-			metadata: {
-				annotations: {
-					[ENVIRONMENT_THEME_ANNOTATION]: 'prod'
-				}
-			}
-		} as any);
+    it('maps production to a non-red preset theme', () => {
+        const theme = getRolloutEnvironmentTheme({
+            metadata: {
+                annotations: {
+                    [ENVIRONMENT_THEME_ANNOTATION]: 'prod'
+                }
+            }
+        } as any);
 
-		expect(theme?.label).toBe('Production');
-		expect(theme?.color).toBe('#d97706');
-		expect(theme?.color).not.toMatch(/^#(?:dc2626|ef4444|f87171)$/);
-	});
+        expect(theme?.label).toBe('Production');
+        expect(theme?.color).toBe('#d97706');
+        expect(theme?.color).not.toMatch(/^#(?:dc2626|ef4444|f87171)$/);
+    });
 
-	it('maps development to the green preset theme', () => {
-		const theme = getRolloutEnvironmentTheme({
-			metadata: {
-				annotations: {
-					[ENVIRONMENT_THEME_ANNOTATION]: 'development'
-				}
-			}
-		} as any);
+    it('maps development to the green preset theme', () => {
+        const theme = getRolloutEnvironmentTheme({
+            metadata: {
+                annotations: {
+                    [ENVIRONMENT_THEME_ANNOTATION]: 'development'
+                }
+            }
+        } as any);
 
-		expect(theme?.label).toBe('Development');
-		expect(theme?.color).toBe('#16a34a');
-	});
+        expect(theme?.label).toBe('Development');
+        expect(theme?.color).toBe('#16a34a');
+    });
 
-	it('uses a custom hex color annotation with an optional label', () => {
-		const theme = getRolloutEnvironmentTheme({
-			metadata: {
-				annotations: {
-					[ENVIRONMENT_THEME_COLOR_ANNOTATION]: '#0EA5E9',
-					[ENVIRONMENT_THEME_LABEL_ANNOTATION]: 'Sandbox'
-				}
-			}
-		} as any);
+    it('uses a custom hex color annotation with an optional label', () => {
+        const theme = getRolloutEnvironmentTheme({
+            metadata: {
+                annotations: {
+                    [ENVIRONMENT_THEME_COLOR_ANNOTATION]: '#0EA5E9',
+                    [ENVIRONMENT_THEME_LABEL_ANNOTATION]: 'Sandbox'
+                }
+            }
+        } as any);
 
-		expect(theme?.label).toBe('Sandbox');
-		expect(theme?.color).toBe('#0ea5e9');
-	});
+        expect(theme?.label).toBe('Sandbox');
+        expect(theme?.color).toBe('#0ea5e9');
+    });
 
-	it('rejects invalid custom color values', () => {
-		const theme = getRolloutEnvironmentTheme({
-			metadata: {
-				annotations: {
-					[ENVIRONMENT_THEME_COLOR_ANNOTATION]: 'url(https://example.com/image.png)'
-				}
-			}
-		} as any);
+    it('rejects invalid custom color values', () => {
+        const theme = getRolloutEnvironmentTheme({
+            metadata: {
+                annotations: {
+                    [ENVIRONMENT_THEME_COLOR_ANNOTATION]: 'url(https://example.com/image.png)'
+                }
+            }
+        } as any);
 
-		expect(theme).toBeNull();
-	});
+        expect(theme).toBeNull();
+    });
 
-	it('returns CSS variables for a parsed theme', () => {
-		const theme = getRolloutEnvironmentTheme({
-			metadata: {
-				annotations: {
-					[ENVIRONMENT_THEME_ANNOTATION]: 'staging'
-				}
-			}
-		} as any);
+    it('returns CSS variables for a parsed theme', () => {
+        const theme = getRolloutEnvironmentTheme({
+            metadata: {
+                annotations: {
+                    [ENVIRONMENT_THEME_ANNOTATION]: 'staging'
+                }
+            }
+        } as any);
 
-		expect(theme).not.toBeNull();
-		expect(getEnvironmentThemeStyle(theme!)).toContain('--rollout-theme-accent: #7c3aed');
-	});
+        expect(theme).not.toBeNull();
+        expect(getEnvironmentThemeStyle(theme!)).toContain('--rollout-theme-accent: #7c3aed');
+    });
 });
 
 describe('extractDatadogInfoFromContainers', () => {
-	it('should return null for empty containers array', () => {
-		expect(extractDatadogInfoFromContainers([])).toBeNull();
-	});
+    it('should return null for empty containers array', () => {
+        expect(extractDatadogInfoFromContainers([])).toBeNull();
+    });
 
-	it('should return null when no DD env vars are present', () => {
-		const containers = [{ env: [{ name: 'FOO', value: 'bar' }] }];
-		expect(extractDatadogInfoFromContainers(containers)).toBeNull();
-	});
+    it('should return null when no DD env vars are present', () => {
+        const containers = [{ env: [{ name: 'FOO', value: 'bar' }] }];
+        expect(extractDatadogInfoFromContainers(containers)).toBeNull();
+    });
 
-	it('should return null when only DD_SERVICE is present', () => {
-		const containers = [{ env: [{ name: 'DD_SERVICE', value: 'my-service' }] }];
-		expect(extractDatadogInfoFromContainers(containers)).toBeNull();
-	});
+    it('should return null when only DD_SERVICE is present', () => {
+        const containers = [{ env: [{ name: 'DD_SERVICE', value: 'my-service' }] }];
+        expect(extractDatadogInfoFromContainers(containers)).toBeNull();
+    });
 
-	it('should return null when only DD_ENV is present', () => {
-		const containers = [{ env: [{ name: 'DD_ENV', value: 'dev' }] }];
-		expect(extractDatadogInfoFromContainers(containers)).toBeNull();
-	});
+    it('should return null when only DD_ENV is present', () => {
+        const containers = [{ env: [{ name: 'DD_ENV', value: 'dev' }] }];
+        expect(extractDatadogInfoFromContainers(containers)).toBeNull();
+    });
 
-	it('should extract service and env when both are present', () => {
-		const containers = [
-			{
-				env: [
-					{ name: 'DD_SERVICE', value: 'my-service' },
-					{ name: 'DD_ENV', value: 'production' }
-				]
-			}
-		];
-		expect(extractDatadogInfoFromContainers(containers)).toEqual({
-			service: 'my-service',
-			env: 'production'
-		});
-	});
+    it('should extract service and env when both are present', () => {
+        const containers = [{
+            env: [
+                { name: 'DD_SERVICE', value: 'my-service' },
+                { name: 'DD_ENV', value: 'production' }
+            ]
+        }];
+        expect(extractDatadogInfoFromContainers(containers)).toEqual({
+            service: 'my-service',
+            env: 'production'
+        });
+    });
 
-	it('should extract service, env and version when all are present', () => {
-		const containers = [
-			{
-				env: [
-					{ name: 'DD_SERVICE', value: 'my-service' },
-					{ name: 'DD_ENV', value: 'production' },
-					{ name: 'DD_VERSION', value: 'main-1770831919-d4cd2de3ed1185943c9105df735a099a2165c7ce' }
-				]
-			}
-		];
-		expect(extractDatadogInfoFromContainers(containers)).toEqual({
-			service: 'my-service',
-			env: 'production',
-			version: 'main-1770831919-d4cd2de3ed1185943c9105df735a099a2165c7ce'
-		});
-	});
+    it('should extract service, env and version when all are present', () => {
+        const containers = [{
+            env: [
+                { name: 'DD_SERVICE', value: 'my-service' },
+                { name: 'DD_ENV', value: 'production' },
+                { name: 'DD_VERSION', value: 'main-1770831919-d4cd2de3ed1185943c9105df735a099a2165c7ce' }
+            ]
+        }];
+        expect(extractDatadogInfoFromContainers(containers)).toEqual({
+            service: 'my-service',
+            env: 'production',
+            version: 'main-1770831919-d4cd2de3ed1185943c9105df735a099a2165c7ce'
+        });
+    });
 
-	it('should return info without version when DD_VERSION is absent', () => {
-		const containers = [
-			{
-				env: [
-					{ name: 'DD_SERVICE', value: 'my-service' },
-					{ name: 'DD_ENV', value: 'staging' }
-				]
-			}
-		];
-		const result = extractDatadogInfoFromContainers(containers);
-		expect(result).toEqual({ service: 'my-service', env: 'staging' });
-		expect(result?.version).toBeUndefined();
-	});
+    it('should return info without version when DD_VERSION is absent', () => {
+        const containers = [{
+            env: [
+                { name: 'DD_SERVICE', value: 'my-service' },
+                { name: 'DD_ENV', value: 'staging' }
+            ]
+        }];
+        const result = extractDatadogInfoFromContainers(containers);
+        expect(result).toEqual({ service: 'my-service', env: 'staging' });
+        expect(result?.version).toBeUndefined();
+    });
 
-	it('should find DD tags in a second container if first has none', () => {
-		const containers = [
-			{ env: [{ name: 'FOO', value: 'bar' }] },
-			{
-				env: [
-					{ name: 'DD_SERVICE', value: 'backend' },
-					{ name: 'DD_ENV', value: 'staging' }
-				]
-			}
-		];
-		expect(extractDatadogInfoFromContainers(containers)).toEqual({
-			service: 'backend',
-			env: 'staging'
-		});
-	});
+    it('should find DD tags in a second container if first has none', () => {
+        const containers = [
+            { env: [{ name: 'FOO', value: 'bar' }] },
+            {
+                env: [
+                    { name: 'DD_SERVICE', value: 'backend' },
+                    { name: 'DD_ENV', value: 'staging' }
+                ]
+            }
+        ];
+        expect(extractDatadogInfoFromContainers(containers)).toEqual({
+            service: 'backend',
+            env: 'staging'
+        });
+    });
 
-	it('should handle containers with no env field', () => {
-		const containers = [{}];
-		expect(extractDatadogInfoFromContainers(containers)).toBeNull();
-	});
+    it('should handle containers with no env field', () => {
+        const containers = [{}];
+        expect(extractDatadogInfoFromContainers(containers)).toBeNull();
+    });
 
-	it('should ignore env vars with empty values', () => {
-		const containers = [
-			{
-				env: [
-					{ name: 'DD_SERVICE', value: '' },
-					{ name: 'DD_ENV', value: 'dev' }
-				]
-			}
-		];
-		expect(extractDatadogInfoFromContainers(containers)).toBeNull();
-	});
+    it('should ignore env vars with empty values', () => {
+        const containers = [{
+            env: [
+                { name: 'DD_SERVICE', value: '' },
+                { name: 'DD_ENV', value: 'dev' }
+            ]
+        }];
+        expect(extractDatadogInfoFromContainers(containers)).toBeNull();
+    });
 });
 
 describe('buildDatadogTestRunsUrl', () => {
-	it('should build a URL with service and version', () => {
-		const url = buildDatadogTestRunsUrl('my-service', 'v1.0.0');
-		expect(url).toContain('https://app.datadoghq.com/ci/test/runs?query=');
-		expect(url).toContain(encodeURIComponent('@test.service:my-service'));
-		expect(url).toContain(encodeURIComponent('@version:v1.0.0'));
-	});
+    it('should build a URL with service and version', () => {
+        const url = buildDatadogTestRunsUrl('my-service', 'v1.0.0');
+        expect(url).toContain('https://app.datadoghq.com/ci/test/runs?query=');
+        expect(url).toContain(encodeURIComponent('@test.service:my-service'));
+        expect(url).toContain(encodeURIComponent('@version:v1.0.0'));
+    });
 });
 
 describe('buildDatadogLogsUrl', () => {
-	it('should build a URL with service and env', () => {
-		const url = buildDatadogLogsUrl('my-service', 'production');
-		expect(url).toContain('https://app.datadoghq.com/logs?query=');
-		expect(url).toContain(encodeURIComponent('service:my-service'));
-		expect(url).toContain(encodeURIComponent('env:production'));
-		expect(url).toContain('&live=true');
-	});
+    it('should build a URL with service and env', () => {
+        const url = buildDatadogLogsUrl('my-service', 'production');
+        expect(url).toContain('https://app.datadoghq.com/logs?query=');
+        expect(url).toContain(encodeURIComponent('service:my-service'));
+        expect(url).toContain(encodeURIComponent('env:production'));
+        expect(url).toContain('&live=true');
+    });
 });
 
 describe('buildDatadogTraceSearchUrl', () => {
-	it('should build a URL with service, env, and version', () => {
-		const url = buildDatadogTraceSearchUrl('my-service', 'production', 'v1.0.0');
-		expect(url).toContain('https://app.datadoghq.com/apm/traces?query=');
-		expect(url).toContain(encodeURIComponent('service:my-service'));
-		expect(url).toContain(encodeURIComponent('env:production'));
-		expect(url).toContain(encodeURIComponent('version:v1.0.0'));
-		// `@rollout.test:true` marker is what distinguishes rollout-test
-		// traces from the service Deployment's regular APM traffic; without
-		// it the search would also surface unrelated traffic.
-		expect(url).toContain(encodeURIComponent('@rollout.test:true'));
-	});
+    it('should build a URL with service, env, and version', () => {
+        const url = buildDatadogTraceSearchUrl('my-service', 'production', 'v1.0.0');
+        expect(url).toContain('https://app.datadoghq.com/apm/traces?query=');
+        expect(url).toContain(encodeURIComponent('service:my-service'));
+        expect(url).toContain(encodeURIComponent('env:production'));
+        expect(url).toContain(encodeURIComponent('version:v1.0.0'));
+        // `@rollout.test:true` marker is what distinguishes rollout-test
+        // traces from the service Deployment's regular APM traffic; without
+        // it the search would also surface unrelated traffic.
+        expect(url).toContain(encodeURIComponent('@rollout.test:true'));
+    });
 
-	it('should omit the version filter when no version is provided', () => {
-		const url = buildDatadogTraceSearchUrl('my-service', 'staging');
-		expect(url).toContain('https://app.datadoghq.com/apm/traces?query=');
-		expect(url).toContain(encodeURIComponent('service:my-service'));
-		expect(url).toContain(encodeURIComponent('env:staging'));
-		expect(url).toContain(encodeURIComponent('@rollout.test:true'));
-		expect(url).not.toContain(encodeURIComponent('version:'));
-	});
+    it('should omit the version filter when no version is provided', () => {
+        const url = buildDatadogTraceSearchUrl('my-service', 'staging');
+        expect(url).toContain('https://app.datadoghq.com/apm/traces?query=');
+        expect(url).toContain(encodeURIComponent('service:my-service'));
+        expect(url).toContain(encodeURIComponent('env:staging'));
+        expect(url).toContain(encodeURIComponent('@rollout.test:true'));
+        expect(url).not.toContain(encodeURIComponent('version:'));
+    });
 });

--- a/frontend/src/routes/rollouts/[namespace]/[name]/+layout.svelte
+++ b/frontend/src/routes/rollouts/[namespace]/[name]/+layout.svelte
@@ -105,64 +105,61 @@
 </script>
 
 <SvelteFlowProvider>
-	<div
-		class="environment-theme-scope flex h-full flex-col overflow-hidden md:flex-row"
-		style={rolloutThemeStyle}
-	>
+	<div class="environment-theme-scope flex h-full flex-col overflow-hidden md:flex-row" style={rolloutThemeStyle}>
 		<!-- Desktop Sidebar (hidden on mobile) -->
 		{#if sidebarMounted}
-			<aside
-				class="hidden flex-shrink-0 border-r border-gray-200 bg-gray-50 md:flex md:flex-col dark:border-gray-700 dark:bg-gray-800 {sidebarCollapsed
-					? 'w-12'
-					: 'w-48'} transition-[width] duration-200"
-			>
-				<!-- Nav items -->
-				<nav class="flex flex-1 flex-col p-2">
-					<SidebarGroup class="space-y-1">
-						{#each navItems.filter((item) => item.show) as item}
-							{@const active = isActive(item.href)}
-							<SidebarItem
-								id="nav-{item.label.toLowerCase()}"
-								href={item.href}
-								label={item.label}
-								{active}
-								{activeClass}
-								{nonActiveClass}
-								spanClass={sidebarCollapsed ? 'hidden' : 'ms-3'}
-								aClass={sidebarCollapsed ? 'justify-center' : ''}
-							>
-								{#snippet icon()}
-									<item.icon class="h-5 w-5 flex-shrink-0" />
-								{/snippet}
-							</SidebarItem>
-							{#if sidebarCollapsed}
-								<Tooltip triggeredBy="#nav-{item.label.toLowerCase()}" placement="right">
-									{item.label}
-								</Tooltip>
-							{/if}
-						{/each}
-					</SidebarGroup>
-				</nav>
-
-				<!-- Collapse toggle at bottom -->
-				<div class="border-t border-gray-200 p-2 dark:border-gray-700">
-					<button
-						class="flex w-full items-center gap-2 rounded-lg px-2 py-2 text-xs text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-300
-						{sidebarCollapsed ? 'justify-center' : ''}"
-						onclick={() => {
-							sidebarCollapsed = !sidebarCollapsed;
-						}}
-						title={sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-					>
+		<aside
+			class="hidden flex-shrink-0 border-r border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-800 md:flex md:flex-col {sidebarCollapsed
+				? 'w-12'
+				: 'w-48'} transition-[width] duration-200"
+		>
+			<!-- Nav items -->
+			<nav class="flex flex-1 flex-col p-2">
+				<SidebarGroup class="space-y-1">
+					{#each navItems.filter((item) => item.show) as item}
+						{@const active = isActive(item.href)}
+						<SidebarItem
+							id="nav-{item.label.toLowerCase()}"
+							href={item.href}
+							label={item.label}
+							{active}
+							{activeClass}
+							{nonActiveClass}
+							spanClass={sidebarCollapsed ? 'hidden' : 'ms-3'}
+							aClass={sidebarCollapsed ? 'justify-center' : ''}
+						>
+							{#snippet icon()}
+								<item.icon class="h-5 w-5 flex-shrink-0" />
+							{/snippet}
+						</SidebarItem>
 						{#if sidebarCollapsed}
-							<AngleRightOutline class="h-4 w-4" />
-						{:else}
-							<AngleLeftOutline class="h-4 w-4" />
-							<span>Collapse</span>
+							<Tooltip triggeredBy="#nav-{item.label.toLowerCase()}" placement="right">
+								{item.label}
+							</Tooltip>
 						{/if}
-					</button>
-				</div>
-			</aside>
+					{/each}
+				</SidebarGroup>
+			</nav>
+
+			<!-- Collapse toggle at bottom -->
+			<div class="border-t border-gray-200 p-2 dark:border-gray-700">
+				<button
+					class="flex w-full items-center gap-2 rounded-lg px-2 py-2 text-xs text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-300
+						{sidebarCollapsed ? 'justify-center' : ''}"
+					onclick={() => {
+						sidebarCollapsed = !sidebarCollapsed;
+					}}
+					title={sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+				>
+					{#if sidebarCollapsed}
+						<AngleRightOutline class="h-4 w-4" />
+					{:else}
+						<AngleLeftOutline class="h-4 w-4" />
+						<span>Collapse</span>
+					{/if}
+				</button>
+			</div>
+		</aside>
 		{/if}
 
 		<!-- Content -->
@@ -174,7 +171,7 @@
 
 		<!-- Mobile Bottom Navigation (hidden on desktop) -->
 		<nav
-			class="fixed right-0 bottom-0 left-0 z-50 border-t border-gray-200 bg-white md:hidden dark:border-gray-700 dark:bg-gray-800"
+			class="fixed bottom-0 left-0 right-0 z-50 border-t border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800 md:hidden"
 		>
 			<div class="flex h-16 items-center justify-around">
 				{#each navItems.filter((item) => item.show) as item}

--- a/frontend/src/routes/rollouts/[namespace]/[name]/+layout.svelte
+++ b/frontend/src/routes/rollouts/[namespace]/[name]/+layout.svelte
@@ -12,11 +12,9 @@
 		AngleRightOutline
 	} from 'flowbite-svelte-icons';
 	import { onMount, type Snippet } from 'svelte';
-	import type { Rollout } from '../../../../types';
 	import { createQuery } from '@tanstack/svelte-query';
 	import { rolloutQueryOptions } from '$lib/api/rollouts';
 	import { SvelteFlowProvider } from '@xyflow/svelte';
-	import { getEnvironmentThemeStyle, getRolloutEnvironmentTheme } from '$lib/environment-theme';
 
 	let { children }: { children: Snippet } = $props();
 
@@ -49,12 +47,7 @@
 		})
 	);
 
-	const rollout = $derived(rolloutQuery.data?.rollout as Rollout | null);
 	const environment = $derived(rolloutQuery.data?.environment);
-	const rolloutTheme = $derived(rollout ? getRolloutEnvironmentTheme(rollout) : null);
-	const rolloutThemeStyle = $derived(
-		rolloutTheme ? getEnvironmentThemeStyle(rolloutTheme) : undefined
-	);
 
 	const hasEnvironment = $derived(
 		environment?.status?.environmentInfos && environment.status.environmentInfos.length > 0
@@ -92,20 +85,14 @@
 		return activeUrl.startsWith(href);
 	};
 
-	const activeClass = $derived(
-		rolloutTheme
-			? 'flex items-center rounded-lg px-2 py-2 text-sm font-medium environment-theme-surface'
-			: 'flex items-center rounded-lg px-2 py-2 text-sm font-medium bg-primary-50 text-primary-700 dark:bg-primary-900/30 dark:text-primary-400'
-	);
-	const mobileActiveClass = $derived(
-		rolloutTheme ? 'environment-theme-text' : 'text-primary-600 dark:text-primary-400'
-	);
+	const activeClass =
+		'flex items-center rounded-lg px-2 py-2 text-sm font-medium bg-primary-50 text-primary-700 dark:bg-primary-900/30 dark:text-primary-400';
 	const nonActiveClass =
 		'flex items-center rounded-lg px-2 py-2 text-sm font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white';
 </script>
 
 <SvelteFlowProvider>
-	<div class="environment-theme-scope flex h-full flex-col overflow-hidden md:flex-row" style={rolloutThemeStyle}>
+	<div class="flex h-full flex-col overflow-hidden md:flex-row">
 		<!-- Desktop Sidebar (hidden on mobile) -->
 		{#if sidebarMounted}
 		<aside
@@ -178,7 +165,7 @@
 					<a
 						href={item.href}
 						class="flex flex-1 flex-col items-center justify-center gap-1 py-2 {isActive(item.href)
-							? mobileActiveClass
+							? 'text-primary-600 dark:text-primary-400'
 							: 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'}"
 					>
 						<item.icon class="h-5 w-5" />

--- a/frontend/src/routes/rollouts/[namespace]/[name]/+layout.svelte
+++ b/frontend/src/routes/rollouts/[namespace]/[name]/+layout.svelte
@@ -16,6 +16,7 @@
 	import { createQuery } from '@tanstack/svelte-query';
 	import { rolloutQueryOptions } from '$lib/api/rollouts';
 	import { SvelteFlowProvider } from '@xyflow/svelte';
+	import { getEnvironmentThemeStyle, getRolloutEnvironmentTheme } from '$lib/environment-theme';
 
 	let { children }: { children: Snippet } = $props();
 
@@ -50,6 +51,10 @@
 
 	const rollout = $derived(rolloutQuery.data?.rollout as Rollout | null);
 	const environment = $derived(rolloutQuery.data?.environment);
+	const rolloutTheme = $derived(rollout ? getRolloutEnvironmentTheme(rollout) : null);
+	const rolloutThemeStyle = $derived(
+		rolloutTheme ? getEnvironmentThemeStyle(rolloutTheme) : undefined
+	);
 
 	const hasEnvironment = $derived(
 		environment?.status?.environmentInfos && environment.status.environmentInfos.length > 0
@@ -87,68 +92,77 @@
 		return activeUrl.startsWith(href);
 	};
 
-	const activeClass =
-		'flex items-center rounded-lg px-2 py-2 text-sm font-medium bg-primary-50 text-primary-700 dark:bg-primary-900/30 dark:text-primary-400';
+	const activeClass = $derived(
+		rolloutTheme
+			? 'flex items-center rounded-lg px-2 py-2 text-sm font-medium environment-theme-surface'
+			: 'flex items-center rounded-lg px-2 py-2 text-sm font-medium bg-primary-50 text-primary-700 dark:bg-primary-900/30 dark:text-primary-400'
+	);
+	const mobileActiveClass = $derived(
+		rolloutTheme ? 'environment-theme-text' : 'text-primary-600 dark:text-primary-400'
+	);
 	const nonActiveClass =
 		'flex items-center rounded-lg px-2 py-2 text-sm font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white';
 </script>
 
 <SvelteFlowProvider>
-	<div class="flex h-full flex-col overflow-hidden md:flex-row">
+	<div
+		class="environment-theme-scope flex h-full flex-col overflow-hidden md:flex-row"
+		style={rolloutThemeStyle}
+	>
 		<!-- Desktop Sidebar (hidden on mobile) -->
 		{#if sidebarMounted}
-		<aside
-			class="hidden flex-shrink-0 border-r border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-800 md:flex md:flex-col {sidebarCollapsed
-				? 'w-12'
-				: 'w-48'} transition-[width] duration-200"
-		>
-			<!-- Nav items -->
-			<nav class="flex flex-1 flex-col p-2">
-				<SidebarGroup class="space-y-1">
-					{#each navItems.filter((item) => item.show) as item}
-						{@const active = isActive(item.href)}
-						<SidebarItem
-							id="nav-{item.label.toLowerCase()}"
-							href={item.href}
-							label={item.label}
-							{active}
-							{activeClass}
-							{nonActiveClass}
-							spanClass={sidebarCollapsed ? 'hidden' : 'ms-3'}
-							aClass={sidebarCollapsed ? 'justify-center' : ''}
-						>
-							{#snippet icon()}
-								<item.icon class="h-5 w-5 flex-shrink-0" />
-							{/snippet}
-						</SidebarItem>
-						{#if sidebarCollapsed}
-							<Tooltip triggeredBy="#nav-{item.label.toLowerCase()}" placement="right">
-								{item.label}
-							</Tooltip>
-						{/if}
-					{/each}
-				</SidebarGroup>
-			</nav>
+			<aside
+				class="hidden flex-shrink-0 border-r border-gray-200 bg-gray-50 md:flex md:flex-col dark:border-gray-700 dark:bg-gray-800 {sidebarCollapsed
+					? 'w-12'
+					: 'w-48'} transition-[width] duration-200"
+			>
+				<!-- Nav items -->
+				<nav class="flex flex-1 flex-col p-2">
+					<SidebarGroup class="space-y-1">
+						{#each navItems.filter((item) => item.show) as item}
+							{@const active = isActive(item.href)}
+							<SidebarItem
+								id="nav-{item.label.toLowerCase()}"
+								href={item.href}
+								label={item.label}
+								{active}
+								{activeClass}
+								{nonActiveClass}
+								spanClass={sidebarCollapsed ? 'hidden' : 'ms-3'}
+								aClass={sidebarCollapsed ? 'justify-center' : ''}
+							>
+								{#snippet icon()}
+									<item.icon class="h-5 w-5 flex-shrink-0" />
+								{/snippet}
+							</SidebarItem>
+							{#if sidebarCollapsed}
+								<Tooltip triggeredBy="#nav-{item.label.toLowerCase()}" placement="right">
+									{item.label}
+								</Tooltip>
+							{/if}
+						{/each}
+					</SidebarGroup>
+				</nav>
 
-			<!-- Collapse toggle at bottom -->
-			<div class="border-t border-gray-200 p-2 dark:border-gray-700">
-				<button
-					class="flex w-full items-center gap-2 rounded-lg px-2 py-2 text-xs text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-300
+				<!-- Collapse toggle at bottom -->
+				<div class="border-t border-gray-200 p-2 dark:border-gray-700">
+					<button
+						class="flex w-full items-center gap-2 rounded-lg px-2 py-2 text-xs text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-300
 						{sidebarCollapsed ? 'justify-center' : ''}"
-					onclick={() => {
-						sidebarCollapsed = !sidebarCollapsed;
-					}}
-					title={sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-				>
-					{#if sidebarCollapsed}
-						<AngleRightOutline class="h-4 w-4" />
-					{:else}
-						<AngleLeftOutline class="h-4 w-4" />
-						<span>Collapse</span>
-					{/if}
-				</button>
-			</div>
-		</aside>
+						onclick={() => {
+							sidebarCollapsed = !sidebarCollapsed;
+						}}
+						title={sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+					>
+						{#if sidebarCollapsed}
+							<AngleRightOutline class="h-4 w-4" />
+						{:else}
+							<AngleLeftOutline class="h-4 w-4" />
+							<span>Collapse</span>
+						{/if}
+					</button>
+				</div>
+			</aside>
 		{/if}
 
 		<!-- Content -->
@@ -160,14 +174,14 @@
 
 		<!-- Mobile Bottom Navigation (hidden on desktop) -->
 		<nav
-			class="fixed bottom-0 left-0 right-0 z-50 border-t border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800 md:hidden"
+			class="fixed right-0 bottom-0 left-0 z-50 border-t border-gray-200 bg-white md:hidden dark:border-gray-700 dark:bg-gray-800"
 		>
 			<div class="flex h-16 items-center justify-around">
 				{#each navItems.filter((item) => item.show) as item}
 					<a
 						href={item.href}
 						class="flex flex-1 flex-col items-center justify-center gap-1 py-2 {isActive(item.href)
-							? 'text-primary-600 dark:text-primary-400'
+							? mobileActiveClass
 							: 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'}"
 					>
 						<item.icon class="h-5 w-5" />

--- a/frontend/src/routes/rollouts/[namespace]/[name]/+page.svelte
+++ b/frontend/src/routes/rollouts/[namespace]/[name]/+page.svelte
@@ -1336,6 +1336,7 @@
 									valueColor="gray"
 									containerClass="environment-theme-scope"
 									containerStyle={rolloutThemeStyle}
+									labelBorder
 									valueClass="environment-theme-badge"
 								/>
 							{:else}

--- a/frontend/src/routes/rollouts/[namespace]/[name]/+page.svelte
+++ b/frontend/src/routes/rollouts/[namespace]/[name]/+page.svelte
@@ -108,6 +108,7 @@
 	import ResourcesCard from '$lib/components/ResourcesCard.svelte';
 	import EventsCard from '$lib/components/EventsCard.svelte';
 	import { fly, blur } from 'svelte/transition';
+	import { getEnvironmentThemeStyle, getRolloutEnvironmentTheme } from '$lib/environment-theme';
 
 	import { createQuery } from '@tanstack/svelte-query';
 	import {
@@ -144,6 +145,11 @@
 
 	// Maintain existing local vars used throughout
 	const rollout = $derived(rolloutQuery.data?.rollout as Rollout | null);
+	const environment = $derived(rolloutQuery.data?.environment);
+	const rolloutTheme = $derived(rollout ? getRolloutEnvironmentTheme(rollout, environment) : null);
+	const rolloutThemeStyle = $derived(
+		rolloutTheme ? getEnvironmentThemeStyle(rolloutTheme) : undefined
+	);
 	const loading = $derived(rolloutQuery.isLoading);
 	let error: string | null = $state(null);
 
@@ -1256,13 +1262,7 @@
 		<div class="px-4 pt-4 pb-10 sm:px-5">
 			{#if rollout.status?.history?.[0]}
 				{@const latestEntry = rollout.status.history[0]}
-				{@const environment = rolloutQuery.data?.environment}
 				{@const currentEnv = environment?.spec?.environment}
-				{@const currentEnvInfo = currentEnv
-					? environment?.status?.environmentInfos?.find(
-							(e: EnvironmentInfo) => e.environment === currentEnv
-						)
-					: undefined}
 				{@const pipelineKruiseRollouts = Object.values(managedResources)
 					.flat()
 					.filter((resource) => resource.groupVersionKind === 'rollouts.kruise.io/v1beta1/Rollout')}
@@ -1328,12 +1328,30 @@
 						<h1 class="text-2xl font-bold text-gray-900 dark:text-white">
 							{rollout.status?.title || rollout.metadata?.name}
 						</h1>
-						{#if currentEnvInfo}
-							<JoinedBadge
-								label="Environment"
-								value={currentEnvInfo.environment || 'N/A'}
-								valueColor="blue"
-							/>
+						{#if currentEnv}
+							{#if rolloutTheme}
+								<div
+									class="environment-theme-scope inline-flex items-center"
+									style={rolloutThemeStyle}
+								>
+									<span
+										class="inline-flex items-center rounded-l-lg border border-r-0 border-gray-200 bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-800 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300"
+									>
+										Environment
+									</span>
+									<span
+										class="environment-theme-badge inline-flex items-center rounded-r-lg px-2.5 py-0.5 text-xs font-medium"
+									>
+										{currentEnv}
+									</span>
+								</div>
+							{:else}
+								<JoinedBadge
+									label="Environment"
+									value={currentEnv}
+									valueColor="blue"
+								/>
+							{/if}
 						{/if}
 					</div>
 					{#if rollout.status?.description}

--- a/frontend/src/routes/rollouts/[namespace]/[name]/+page.svelte
+++ b/frontend/src/routes/rollouts/[namespace]/[name]/+page.svelte
@@ -1336,7 +1336,6 @@
 									valueColor="gray"
 									containerClass="environment-theme-scope"
 									containerStyle={rolloutThemeStyle}
-									labelBorder
 									valueClass="environment-theme-badge"
 								/>
 							{:else}

--- a/frontend/src/routes/rollouts/[namespace]/[name]/+page.svelte
+++ b/frontend/src/routes/rollouts/[namespace]/[name]/+page.svelte
@@ -1336,7 +1336,7 @@
 									valueColor="gray"
 									containerClass="environment-theme-scope"
 									containerStyle={rolloutThemeStyle}
-									labelClass="border-y border-l border-gray-300 dark:border-gray-600"
+									labelPlainBorder
 									valueClass="environment-theme-badge"
 								/>
 							{:else}

--- a/frontend/src/routes/rollouts/[namespace]/[name]/+page.svelte
+++ b/frontend/src/routes/rollouts/[namespace]/[name]/+page.svelte
@@ -1330,21 +1330,14 @@
 						</h1>
 						{#if currentEnv}
 							{#if rolloutTheme}
-								<div
-									class="environment-theme-scope inline-flex items-center"
-									style={rolloutThemeStyle}
-								>
-									<span
-										class="inline-flex items-center rounded-l-lg border border-r-0 border-gray-200 bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-800 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300"
-									>
-										Environment
-									</span>
-									<span
-										class="environment-theme-badge inline-flex items-center rounded-r-lg px-2.5 py-0.5 text-xs font-medium"
-									>
-										{currentEnv}
-									</span>
-								</div>
+								<JoinedBadge
+									label="Environment"
+									value={currentEnv}
+									valueColor="gray"
+									containerClass="environment-theme-scope"
+									containerStyle={rolloutThemeStyle}
+									valueClass="environment-theme-badge"
+								/>
 							{:else}
 								<JoinedBadge
 									label="Environment"

--- a/frontend/src/routes/rollouts/[namespace]/[name]/+page.svelte
+++ b/frontend/src/routes/rollouts/[namespace]/[name]/+page.svelte
@@ -1336,6 +1336,7 @@
 									valueColor="gray"
 									containerClass="environment-theme-scope"
 									containerStyle={rolloutThemeStyle}
+									labelClass="border-y border-l border-gray-100 dark:border-gray-900"
 									valueClass="environment-theme-badge"
 								/>
 							{:else}

--- a/frontend/src/routes/rollouts/[namespace]/[name]/+page.svelte
+++ b/frontend/src/routes/rollouts/[namespace]/[name]/+page.svelte
@@ -1336,7 +1336,7 @@
 									valueColor="gray"
 									containerClass="environment-theme-scope"
 									containerStyle={rolloutThemeStyle}
-									labelClass="border-y border-l border-gray-100 dark:border-gray-900"
+									labelClass="border-y border-l border-gray-300 dark:border-gray-600"
 									valueClass="environment-theme-badge"
 								/>
 							{:else}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add rollout annotation parsing for dashboard environment themes and custom hex colors
- Infer detail-page themes from related Environment `spec.environment` values like `eu-prod-1`
- Let rollout theme annotations explicitly override inferred Environment themes when necessary
- Apply subtle themed accents to the navbar and environment badges using Flowbite `Badge`/`JoinedBadge`
- Add optional bordered and plain-border left-label support to `JoinedBadge`; Environment uses `labelPlainBorder` when paired with a bordered themed value
- Keep switcher hover/active and detail sidebar navigation highlighting on their existing neutral styles
- Remove rollout-list themed border/rail treatment so status coloring remains the primary card signal
- Indicate the current rollout in the switcher with a slim left accent bar instead of an additional badge/ring
- Document theme inference/annotation override precedence and add environment theme annotations to examples

## Testing
- Passed: `./node_modules/.bin/vitest run src/lib/utils.test.ts` (41 tests)
- Failed (pre-existing repository diagnostics): `npm run check`
  - Missing Node typings for `process`/`async_hooks`
  - Existing Flowbite `Badge color="none"` type issue
  - Existing DeploymentPipelineCard phase comparison issue
  - Existing `ScheduleStatus.svelte` `$lib/types` import issue
  - Existing `imageRepoScanTime` type issue and a11y/CSS warnings
- Failed (pre-existing test setup): `./node_modules/.bin/vitest run`
  - `src/routes/page.svelte.test.ts` renders the page without a TanStack QueryClientProvider
- Not run: example `kustomize` builds (`kustomize`/`kubectl` are not installed in this environment)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SRE-495](https://linear.app/caffeinelabs/issue/SRE-495/support-environment-color-themes-in-kuberik-dashboard)

<div><a href="https://cursor.com/agents/bc-4238eb05-5948-476a-8eeb-504ad6ea0793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4238eb05-5948-476a-8eeb-504ad6ea0793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

