### PR TITLE
Redesign rollout list as grouped control panel

### DIFF
--- a/frontend/src/lib/Rollouts.svelte
+++ b/frontend/src/lib/Rollouts.svelte
@@ -496,7 +496,7 @@
 
 		<!-- Expandable filter panel -->
 		{#if showFilters}
-			<div id="filter-panel" transition:slide={{ duration: 150 }} class="border-t border-gray-100 bg-gray-50/50 dark:border-gray-700/60 dark:bg-gray-900/30">
+			<div id="filter-panel" transition:slide={{ duration: 180 }} class="border-t border-gray-100 bg-gray-50/70 dark:border-gray-700/60 dark:bg-gray-900/40">
 				<div class="grid gap-x-6 gap-y-4 px-4 py-4 sm:grid-cols-2 sm:px-6 lg:grid-cols-3">
 					<!-- Status section -->
 					<section>
@@ -605,19 +605,22 @@
 	</header>
 
 	<!-- ── Group cards grid ── -->
-	<div class="flex-1 bg-gray-50 px-4 py-5 dark:bg-gray-900/50 sm:px-6 sm:py-6">
+	<div class="flex-1 bg-gray-50/70 px-4 py-5 dark:bg-gray-900/40 sm:px-6 sm:py-6">
 		{#if loading}
-			<div class="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+			<div class="grid grid-cols-1 gap-5 sm:grid-cols-2 xl:grid-cols-3">
 				{#each Array(6) as _}
-					<div class="rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
-						<div class="border-b border-gray-100 px-4 py-2.5 dark:border-gray-700/60">
-							<div class="h-4 w-32 animate-pulse rounded bg-gray-200 dark:bg-gray-700"></div>
+					<div class="rounded-xl border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800">
+						<div class="border-b border-gray-100 px-4 py-3 dark:border-gray-700/60">
+							<div class="h-3.5 w-32 animate-pulse rounded bg-gray-200 dark:bg-gray-700"></div>
 						</div>
-						<div class="space-y-3 p-4">
+						<div class="divide-y divide-gray-100 dark:divide-gray-700/60">
 							{#each Array(2) as _}
-								<div>
-									<div class="h-3.5 w-3/4 animate-pulse rounded bg-gray-200 dark:bg-gray-700"></div>
-									<div class="mt-1.5 h-2.5 w-1/2 animate-pulse rounded bg-gray-100 dark:bg-gray-700"></div>
+								<div class="px-4 py-3">
+									<div class="flex items-center gap-2.5">
+										<div class="h-2 w-2 shrink-0 animate-pulse rounded-full bg-gray-200 dark:bg-gray-700"></div>
+										<div class="h-3.5 w-1/2 animate-pulse rounded bg-gray-200 dark:bg-gray-700"></div>
+									</div>
+									<div class="mt-2 h-2.5 w-2/3 animate-pulse rounded bg-gray-100 pl-[18px] dark:bg-gray-700/60"></div>
 								</div>
 							{/each}
 						</div>
@@ -634,42 +637,48 @@
 				<button onclick={() => { searchQuery = ''; statusFilters = []; envFilters = []; nsFilters = []; }} class="mt-3 inline-flex items-center gap-1 rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600">Clear filters</button>
 			</div>
 		{:else}
-			<div class="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+			<div class="grid grid-cols-1 gap-5 sm:grid-cols-2 xl:grid-cols-3">
 				{#each groupedRows as group}
 					{@const drift = groupBy === 'name' && group.versions.size > 1}
 					{@const groupHighlighted =
 						(group.labelKind === 'namespace' && nsFilters.includes(group.key)) ||
 						(group.labelKind === 'environment' && envFilters.includes(group.key))}
-					<section class="overflow-hidden rounded-lg border bg-white transition-shadow hover:shadow-sm dark:bg-gray-800
+					<section class="group/card overflow-hidden rounded-xl border bg-white shadow-sm transition-all hover:shadow-md dark:bg-gray-800
 						{groupHighlighted ? 'border-blue-300 dark:border-blue-700' : 'border-gray-200 dark:border-gray-700'}"
 					>
-						<!-- Group header (neutral, calm) -->
+						<!-- Group header (calm, refined) -->
 						<button
 							type="button"
 							onclick={() => toggleGroupKey(group)}
 							aria-pressed={groupHighlighted}
-							class="flex w-full items-center justify-between gap-2 border-b border-gray-100 px-4 py-2.5 text-left transition-colors hover:bg-gray-50 dark:border-gray-700/60 dark:hover:bg-gray-700/30"
+							class="flex w-full items-center justify-between gap-2 border-b border-gray-100 px-4 py-3 text-left transition-colors hover:bg-gray-50/80 dark:border-gray-700/60 dark:hover:bg-gray-700/30"
 						>
-							<div class="flex min-w-0 items-center gap-2">
-								<!-- Severity indicator (only when non-healthy) — small dot, not a tinted bg -->
+							<div class="flex min-w-0 items-center gap-2.5">
+								<!-- Severity indicator — only when not healthy -->
 								{#if group.severity === 3}
-									<span class="h-1.5 w-1.5 shrink-0 rounded-full bg-red-500" title="{group.failedCount} failed"></span>
+									<span class="relative flex h-2 w-2 shrink-0">
+										<span class="absolute inline-flex h-full w-full animate-ping rounded-full bg-red-400 opacity-50"></span>
+										<span class="relative inline-flex h-2 w-2 rounded-full bg-red-500" title="{group.failedCount} failed"></span>
+									</span>
 								{:else if group.severity === 2}
-									<span class="h-1.5 w-1.5 shrink-0 rounded-full bg-orange-500" title="{group.stuckCount} stuck"></span>
+									<span class="h-2 w-2 shrink-0 rounded-full bg-orange-500" title="{group.stuckCount} stuck"></span>
 								{:else if group.severity === 1}
-									<span class="h-1.5 w-1.5 shrink-0 rounded-full bg-yellow-400" title="{group.activeCount} active"></span>
+									<span class="relative flex h-2 w-2 shrink-0">
+										<span class="absolute inline-flex h-full w-full animate-ping rounded-full bg-yellow-300 opacity-50"></span>
+										<span class="relative inline-flex h-2 w-2 rounded-full bg-yellow-400" title="{group.activeCount} active"></span>
+									</span>
 								{/if}
 								{#if group.labelKind === 'environment'}
 									<Badge color="dark" border rounded class="environment-theme-badge"
 										style={(group.rows[0]?.theme) ? getEnvironmentThemeStyle(group.rows[0].theme) : undefined}
 									>{group.label}</Badge>
 								{:else}
-									<h3 class="truncate text-xs
+									<h3 class="truncate text-[13px] tracking-tight
 										{group.labelKind === 'name' ? 'font-semibold text-gray-900 dark:text-white' : 'font-mono font-semibold text-gray-700 dark:text-gray-200'}
 										{groupHighlighted ? 'text-blue-600 dark:text-blue-400' : ''}"
 									>{group.label}</h3>
 								{/if}
-								<span class="shrink-0 text-[11px] tabular-nums text-gray-400 dark:text-gray-500">{group.rows.length}</span>
+								<span class="shrink-0 rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium tabular-nums text-gray-500 dark:bg-gray-700/60 dark:text-gray-400">{group.rows.length}</span>
 								{#if drift}
 									<Badge color="orange" rounded class="text-[10px]" title="Versions differ across deployments">drift</Badge>
 								{/if}
@@ -687,8 +696,11 @@
 									<a
 										href="/rollouts/{row.ns}/{row.name}"
 										style={row.theme ? getEnvironmentThemeStyle(row.theme) : undefined}
-										class="environment-theme-scope relative block px-4 py-3 transition-colors hover:bg-gray-50/80 dark:hover:bg-gray-700/30"
+										class="environment-theme-scope group/row relative block px-4 py-3 transition-colors hover:bg-gray-50/80 dark:hover:bg-gray-700/30"
 									>
+										<!-- Subtle hover indicator slides in from left -->
+										<span class="pointer-events-none absolute inset-y-2 left-0 w-0.5 origin-top scale-y-0 rounded-r-full bg-blue-400 transition-transform duration-200 group-hover/row:scale-y-100 dark:bg-blue-500"></span>
+
 										<!-- Line 1: dot + name + env -->
 										<div class="flex items-center gap-2.5">
 											<span class="relative flex h-2 w-2 shrink-0">
@@ -698,15 +710,15 @@
 												<span class="relative inline-flex h-2 w-2 rounded-full {badge.dot}"></span>
 											</span>
 											{#if groupBy === 'name'}
-												<h4 class="min-w-0 flex-1 truncate font-mono text-[12.5px] text-gray-700 dark:text-gray-300">{row.ns}</h4>
+												<h4 class="min-w-0 flex-1 truncate font-mono text-[13px] text-gray-700 transition-colors group-hover/row:text-gray-900 dark:text-gray-300 dark:group-hover/row:text-white">{row.ns}</h4>
 												{#if row.theme}
 													<Badge color="dark" border rounded class="environment-theme-badge shrink-0">{row.theme.label}</Badge>
 												{/if}
 											{:else if groupBy === 'environment'}
-												<h4 class="min-w-0 flex-1 truncate text-sm font-semibold text-gray-900 dark:text-white">{row.name}</h4>
+												<h4 class="min-w-0 flex-1 truncate text-[14px] font-semibold tracking-tight text-gray-900 dark:text-white">{row.name}</h4>
 												<span class="shrink-0 truncate font-mono text-[11px] text-gray-400 dark:text-gray-500">{row.ns}</span>
 											{:else}
-												<h4 class="min-w-0 flex-1 truncate text-sm font-semibold text-gray-900 dark:text-white">{row.name}</h4>
+												<h4 class="min-w-0 flex-1 truncate text-[14px] font-semibold tracking-tight text-gray-900 dark:text-white">{row.name}</h4>
 												{#if row.theme}
 													<Badge color="dark" border rounded class="environment-theme-badge shrink-0">{row.theme.label}</Badge>
 												{/if}
@@ -766,21 +778,23 @@
 											</div>
 										</div>
 
-										<!-- Subtle per-rollout timeline (light dots on a hairline) -->
+										<!-- Subtle per-rollout deploy timeline -->
 										{#if row.displayHistory.length > 0}
-											<div class="mt-2 pl-[18px]">
+											<div class="mt-2.5 pl-[18px]">
 												<div class="relative h-1.5">
-													<div class="absolute inset-x-0 top-[3px] h-px bg-gray-100 dark:bg-gray-700/40"></div>
+													<div class="absolute inset-x-0 top-[3px] h-px bg-gradient-to-r from-gray-200/40 via-gray-200 to-gray-300/80 dark:from-gray-700/30 dark:via-gray-700/60 dark:to-gray-600/80"></div>
 													{#each row.displayHistory as h}
 														{@const t = new Date(h.ts).getTime()}
 														{@const x = Math.min(100, Math.max(0, ((t - group.rangeMin) / group.rangeSpan) * 100))}
 														{@const b = STATUS_BADGE[h.status] ?? STATUS_BADGE['None']}
 														<span
-															class="absolute top-0 h-1.5 w-1.5 -translate-x-1/2 rounded-full {b.sparkBg}"
+															class="absolute top-0 h-1.5 w-1.5 -translate-x-1/2 rounded-full {b.sparkBg} ring-1 ring-white transition-transform hover:scale-150 dark:ring-gray-800"
 															style="left: {x}%"
 															title="{h.version} · {h.status}"
 														></span>
 													{/each}
+													<!-- 'now' dot anchor on the right -->
+													<span class="absolute right-0 top-0 h-1.5 w-1.5 rounded-full bg-gray-300 ring-1 ring-white dark:bg-gray-600 dark:ring-gray-800" title="now"></span>
 												</div>
 											</div>
 										{/if}

--- a/frontend/src/lib/Rollouts.svelte
+++ b/frontend/src/lib/Rollouts.svelte
@@ -394,7 +394,7 @@
 	];
 </script>
 
-<div class="flex min-h-full flex-col bg-gray-50/40 dark:bg-gray-900/30">
+<div class="flex min-h-full flex-col bg-white dark:bg-gray-900">
 
 	<!-- ── Toolbar: search + Filter button + active chips + group-by ── -->
 	<header class="sticky top-0 z-20 border-b border-gray-200 bg-white/95 backdrop-blur dark:border-gray-700 dark:bg-gray-800/95">
@@ -459,7 +459,7 @@
 			</div>
 		</div>
 
-		<!-- Row 2: active filter chips (own row so they never push the group toggle) -->
+		<!-- Row 2: active filter chips (ghost style, own row) -->
 		{#if !showFilters && activeFilterCount > 0}
 			<div class="flex flex-wrap items-center gap-1 px-4 pb-2 sm:px-6">
 				{#each statusFilters as k}
@@ -468,16 +468,11 @@
 						type="button"
 						onclick={() => toggleStatus(k)}
 						title="Remove filter"
-						class="inline-flex h-5 cursor-pointer items-center gap-1 rounded-full border px-1.5 text-[10px] font-medium transition-colors
-							{meta.color === 'red'    ? 'border-red-300 bg-red-100 text-red-800 hover:bg-red-200/70 dark:border-red-800/60 dark:bg-red-900/40 dark:text-red-200'
-							: meta.color === 'yellow' ? 'border-yellow-300 bg-yellow-100 text-yellow-800 hover:bg-yellow-200/70 dark:border-yellow-800/60 dark:bg-yellow-900/40 dark:text-yellow-200'
-							: meta.color === 'green'  ? 'border-green-300 bg-green-100 text-green-800 hover:bg-green-200/70 dark:border-green-800/60 dark:bg-green-900/40 dark:text-green-200'
-							: meta.color === 'orange' ? 'border-orange-300 bg-orange-100 text-orange-800 hover:bg-orange-200/70 dark:border-orange-800/60 dark:bg-orange-900/40 dark:text-orange-200'
-							:                           'border-gray-300 bg-gray-100 text-gray-800 hover:bg-gray-200/70 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100'}"
+						class="inline-flex h-5 cursor-pointer items-center gap-1 rounded border border-gray-200 bg-white px-1.5 text-[10px] font-medium text-gray-600 transition-colors hover:border-gray-300 hover:text-gray-900 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-gray-600 dark:hover:text-gray-100"
 					>
 						<span class="h-1.5 w-1.5 rounded-full {meta.dot}"></span>
 						{meta.label}
-						<CloseOutline class="h-2.5 w-2.5 opacity-70" />
+						<CloseOutline class="h-2.5 w-2.5 opacity-50" />
 					</button>
 				{/each}
 				{#each envFilters as env}
@@ -485,16 +480,16 @@
 						type="button"
 						onclick={() => toggleEnv(env)}
 						title="Remove filter"
-						class="inline-flex h-5 cursor-pointer items-center gap-1 rounded-full border border-blue-300 bg-blue-100 px-1.5 text-[10px] font-semibold uppercase tracking-wider text-blue-800 transition-colors hover:bg-blue-200/70 dark:border-blue-800/60 dark:bg-blue-900/40 dark:text-blue-200"
-					>{env}<CloseOutline class="h-2.5 w-2.5 opacity-70" /></button>
+						class="inline-flex h-5 cursor-pointer items-center gap-1 rounded border border-gray-200 bg-white px-1.5 text-[10px] font-semibold uppercase tracking-wider text-gray-600 transition-colors hover:border-gray-300 hover:text-gray-900 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-gray-600 dark:hover:text-gray-100"
+					>{env}<CloseOutline class="h-2.5 w-2.5 opacity-50" /></button>
 				{/each}
 				{#each nsFilters as ns}
 					<button
 						type="button"
 						onclick={() => toggleNs(ns)}
 						title="Remove filter"
-						class="inline-flex h-5 cursor-pointer items-center gap-1 rounded-full border border-gray-300 bg-gray-100 px-1.5 font-mono text-[10px] font-medium text-gray-800 transition-colors hover:bg-gray-200/70 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-					>{ns}<CloseOutline class="h-2.5 w-2.5 opacity-70" /></button>
+						class="inline-flex h-5 cursor-pointer items-center gap-1 rounded border border-gray-200 bg-white px-1.5 font-mono text-[10px] font-medium text-gray-600 transition-colors hover:border-gray-300 hover:text-gray-900 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-gray-600 dark:hover:text-gray-100"
+					>{ns}<CloseOutline class="h-2.5 w-2.5 opacity-50" /></button>
 				{/each}
 			</div>
 		{/if}
@@ -610,7 +605,7 @@
 	</header>
 
 	<!-- ── Group cards grid ── -->
-	<div class="flex-1 px-4 py-4 sm:px-6">
+	<div class="flex-1 bg-gray-50 px-4 py-5 dark:bg-gray-900/50 sm:px-6 sm:py-6">
 		{#if loading}
 			<div class="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
 				{#each Array(6) as _}
@@ -645,34 +640,33 @@
 					{@const groupHighlighted =
 						(group.labelKind === 'namespace' && nsFilters.includes(group.key)) ||
 						(group.labelKind === 'environment' && envFilters.includes(group.key))}
-					<section class="overflow-hidden rounded-lg border bg-white shadow-sm transition-all hover:shadow-md dark:bg-gray-800
-						{groupHighlighted ? 'border-blue-400 dark:border-blue-500' : 'border-gray-200 dark:border-gray-700'}"
+					<section class="overflow-hidden rounded-lg border bg-white transition-shadow hover:shadow-sm dark:bg-gray-800
+						{groupHighlighted ? 'border-blue-300 dark:border-blue-700' : 'border-gray-200 dark:border-gray-700'}"
 					>
-						<!-- Group header -->
+						<!-- Group header (neutral, calm) -->
 						<button
 							type="button"
 							onclick={() => toggleGroupKey(group)}
 							aria-pressed={groupHighlighted}
-							class="flex w-full items-center justify-between gap-2 border-b px-4 py-2.5 text-left transition-colors
-								{groupHighlighted
-									? 'border-blue-200 bg-blue-50 hover:bg-blue-100/70 dark:border-blue-800/40 dark:bg-blue-900/20 dark:hover:bg-blue-900/30'
-									: group.severity === 3
-										? 'border-red-100 bg-red-50/60 hover:bg-red-50 dark:border-red-900/40 dark:bg-red-900/10 dark:hover:bg-red-900/20'
-										: group.severity === 2
-											? 'border-orange-100 bg-orange-50/60 hover:bg-orange-50 dark:border-orange-900/40 dark:bg-orange-900/10 dark:hover:bg-orange-900/20'
-											: group.severity === 1
-												? 'border-yellow-100 bg-yellow-50/60 hover:bg-yellow-50 dark:border-yellow-900/40 dark:bg-yellow-900/10 dark:hover:bg-yellow-900/20'
-												: 'border-gray-100 bg-gray-50/60 hover:bg-gray-100 dark:border-gray-700/60 dark:bg-gray-800/60 dark:hover:bg-gray-700/40'}"
+							class="flex w-full items-center justify-between gap-2 border-b border-gray-100 px-4 py-2.5 text-left transition-colors hover:bg-gray-50 dark:border-gray-700/60 dark:hover:bg-gray-700/30"
 						>
-							<div class="flex min-w-0 items-baseline gap-2">
+							<div class="flex min-w-0 items-center gap-2">
+								<!-- Severity indicator (only when non-healthy) — small dot, not a tinted bg -->
+								{#if group.severity === 3}
+									<span class="h-1.5 w-1.5 shrink-0 rounded-full bg-red-500" title="{group.failedCount} failed"></span>
+								{:else if group.severity === 2}
+									<span class="h-1.5 w-1.5 shrink-0 rounded-full bg-orange-500" title="{group.stuckCount} stuck"></span>
+								{:else if group.severity === 1}
+									<span class="h-1.5 w-1.5 shrink-0 rounded-full bg-yellow-400" title="{group.activeCount} active"></span>
+								{/if}
 								{#if group.labelKind === 'environment'}
 									<Badge color="dark" border rounded class="environment-theme-badge"
 										style={(group.rows[0]?.theme) ? getEnvironmentThemeStyle(group.rows[0].theme) : undefined}
 									>{group.label}</Badge>
 								{:else}
-									<h3 class="truncate text-xs font-semibold
-										{group.labelKind === 'name' ? 'text-gray-900 dark:text-white' : 'font-mono text-gray-700 dark:text-gray-200'}
-										{groupHighlighted ? 'text-blue-700 dark:text-blue-300' : ''}"
+									<h3 class="truncate text-xs
+										{group.labelKind === 'name' ? 'font-semibold text-gray-900 dark:text-white' : 'font-mono font-semibold text-gray-700 dark:text-gray-200'}
+										{groupHighlighted ? 'text-blue-600 dark:text-blue-400' : ''}"
 									>{group.label}</h3>
 								{/if}
 								<span class="shrink-0 text-[11px] tabular-nums text-gray-400 dark:text-gray-500">{group.rows.length}</span>
@@ -680,63 +674,37 @@
 									<Badge color="orange" rounded class="text-[10px]" title="Versions differ across deployments">drift</Badge>
 								{/if}
 							</div>
-							<div class="flex shrink-0 items-center gap-1.5">
-								<!-- Status badges -->
-								{#if group.failedCount > 0}
-									<Badge color="red" rounded class="text-[10px]">{group.failedCount} failed</Badge>
-								{:else if group.stuckCount > 0}
-									<Badge color="orange" rounded class="text-[10px]">{group.stuckCount} stuck</Badge>
-								{:else if group.activeCount > 0}
-									<Badge color="yellow" rounded class="text-[10px]">{group.activeCount} active</Badge>
-								{:else}
-									<CheckCircleSolid class="h-3.5 w-3.5 text-green-500 dark:text-green-400" />
-								{/if}
-								{#if groupHighlighted}
-									<CloseOutline class="h-3.5 w-3.5 text-blue-500" />
-								{/if}
-							</div>
+							{#if groupHighlighted}
+								<CloseOutline class="h-3.5 w-3.5 text-blue-500" />
+							{/if}
 						</button>
-
-						<!-- Group time-axis labels (oldest → now) -->
-						{#if group.rangeSpan > 60000}
-							<div class="flex justify-between border-b border-gray-100 px-4 pt-1 pb-0.5 font-mono text-[9px] uppercase tracking-wider text-gray-400 dark:border-gray-700/60 dark:text-gray-500">
-								<span>{compactSeconds(Math.floor(($now.getTime() - group.rangeMin) / 1000))} ago</span>
-								<span>now</span>
-							</div>
-						{/if}
 
 						<!-- Rows -->
 						<ul class="divide-y divide-gray-100 dark:divide-gray-700/60">
 							{#each group.rows as row}
 								{@const badge = STATUS_BADGE[row.status] ?? STATUS_BADGE['None']}
-								{@const rowTint = row.status === 'Failed'
-									? 'bg-red-50/40 dark:bg-red-900/10 hover:bg-red-50/70 dark:hover:bg-red-900/20'
-									: isRunning(row.status)
-										? 'bg-yellow-50/30 dark:bg-yellow-900/5 hover:bg-yellow-50/60 dark:hover:bg-yellow-900/10'
-										: 'hover:bg-gray-50 dark:hover:bg-gray-700/40'}
 								<li>
 									<a
 										href="/rollouts/{row.ns}/{row.name}"
 										style={row.theme ? getEnvironmentThemeStyle(row.theme) : undefined}
-										class="environment-theme-scope relative block px-4 py-2.5 transition-colors {rowTint}"
+										class="environment-theme-scope relative block px-4 py-3 transition-colors hover:bg-gray-50/80 dark:hover:bg-gray-700/30"
 									>
-										<!-- Line 1: dot + identity + secondary tags -->
-										<div class="flex items-center gap-2">
+										<!-- Line 1: dot + name + env -->
+										<div class="flex items-center gap-2.5">
 											<span class="relative flex h-2 w-2 shrink-0">
 												{#if isRunning(row.status)}
 													<span class="absolute inline-flex h-full w-full animate-ping rounded-full opacity-60 {badge.dot}"></span>
 												{/if}
 												<span class="relative inline-flex h-2 w-2 rounded-full {badge.dot}"></span>
 											</span>
-											<!-- Primary identity (changes by grouping mode) -->
 											{#if groupBy === 'name'}
-												<h4 class="min-w-0 flex-1 truncate font-mono text-[12px] text-gray-700 dark:text-gray-300">{row.ns}</h4>
+												<h4 class="min-w-0 flex-1 truncate font-mono text-[12.5px] text-gray-700 dark:text-gray-300">{row.ns}</h4>
 												{#if row.theme}
 													<Badge color="dark" border rounded class="environment-theme-badge shrink-0">{row.theme.label}</Badge>
 												{/if}
 											{:else if groupBy === 'environment'}
 												<h4 class="min-w-0 flex-1 truncate text-sm font-semibold text-gray-900 dark:text-white">{row.name}</h4>
-												<span class="shrink-0 truncate font-mono text-[11px] text-gray-500 dark:text-gray-500">{row.ns}</span>
+												<span class="shrink-0 truncate font-mono text-[11px] text-gray-400 dark:text-gray-500">{row.ns}</span>
 											{:else}
 												<h4 class="min-w-0 flex-1 truncate text-sm font-semibold text-gray-900 dark:text-white">{row.name}</h4>
 												{#if row.theme}
@@ -745,69 +713,70 @@
 											{/if}
 										</div>
 
-										<!-- Line 2: status · version · signals · age -->
-										<div class="mt-1 flex flex-wrap items-center gap-x-1.5 gap-y-0.5 pl-4 text-[11px] text-gray-500 dark:text-gray-400">
-											<span class="shrink-0 {row.status === 'Failed' ? 'font-medium text-red-600 dark:text-red-400' : isRunning(row.status) ? 'font-medium text-yellow-700 dark:text-yellow-400' : ''}">
-												{badge.label}{#if row.bakeProgressPct !== null}&nbsp;{Math.round(row.bakeProgressPct)}%{/if}
-											</span>
+										<!-- Line 2: minimal meta — version, age, and ONLY non-healthy signals -->
+										<div class="mt-1 flex items-center gap-x-2 pl-[18px] text-[11px] text-gray-500 dark:text-gray-500">
+											<!-- Status label only when not Healthy/Idle (those are implied by the dot) -->
+											{#if row.status === 'Failed'}
+												<span class="shrink-0 font-medium text-red-600 dark:text-red-400">Failed</span>
+												<span class="text-gray-300 dark:text-gray-700">·</span>
+											{:else if isRunning(row.status)}
+												<span class="shrink-0 font-medium text-yellow-700 dark:text-yellow-400">
+													{badge.label}{#if row.bakeProgressPct !== null}&nbsp;{Math.round(row.bakeProgressPct)}%{/if}
+												</span>
+												<span class="text-gray-300 dark:text-gray-700">·</span>
+											{/if}
+
 											{#if row.version}
-												<span class="text-gray-300 dark:text-gray-600">·</span>
 												<span class="min-w-0 truncate font-mono">{row.version}</span>
+											{:else}
+												<span class="text-gray-300 dark:text-gray-700">no version</span>
 											{/if}
-											{#if row.pinnedVersion}
-												<span class="text-gray-300 dark:text-gray-600">·</span>
-												<span
-													class="inline-flex shrink-0 items-center gap-0.5 font-medium text-orange-600 dark:text-orange-400"
-													title="Pinned to {row.pinnedVersion} — automated deploys are paused until the pin is cleared"
-												>
-													<PauseSolid class="h-3 w-3" />pinned
-												</span>
-											{/if}
-											{#if row.isStuck || row.waitingCandidateVersion}
-												{@const waitId = `wait-${row.ns}-${row.name}`.replace(/[^a-z0-9-]/gi, '-')}
-												<span class="text-gray-300 dark:text-gray-600">·</span>
-												<span
-													id={waitId}
-													class="inline-flex shrink-0 cursor-help items-center gap-0.5
-														{row.isStuck ? 'font-medium text-orange-600 dark:text-orange-400' : 'text-gray-500 dark:text-gray-400'}"
-												>
-													<ClockSolid class="h-3 w-3" />
-													{row.isStuck ? 'stuck' : 'waiting'} {compactSeconds(row.waitingSeconds)}
-													<QuestionCircleOutline class="ml-0.5 h-3 w-3 opacity-60" />
-												</span>
-											{:else if row.upgradeCount > 0}
-												<span class="text-gray-300 dark:text-gray-600">·</span>
-												<span class="inline-flex shrink-0 items-center gap-0.5 tabular-nums text-gray-500 dark:text-gray-400" title="{row.upgradeCount} pending upgrades">
-													<ArrowUpOutline class="h-3 w-3" />{row.upgradeCount}
-												</span>
-											{/if}
-											{#if row.failedHCCount > 0}
-												<span class="text-gray-300 dark:text-gray-600">·</span>
-												<span class="inline-flex shrink-0 items-center gap-0.5 tabular-nums text-red-600 dark:text-red-400" title="{row.failedHCCount} failed health checks">
-													<HeartSolid class="h-3 w-3" />{row.failedHCCount}
-												</span>
-											{/if}
-											{#if row.age}
-												<span class="text-gray-300 dark:text-gray-600">·</span>
-												<span class="shrink-0 font-mono tabular-nums">{row.age}</span>
-											{/if}
+
+											<!-- Trailing signals (right-aligned, icon-only) -->
+											<div class="ml-auto flex shrink-0 items-center gap-2 tabular-nums">
+												{#if row.pinnedVersion}
+													<span class="inline-flex items-center text-orange-500 dark:text-orange-400" title="Pinned to {row.pinnedVersion}">
+														<PauseSolid class="h-3 w-3" />
+													</span>
+												{/if}
+												{#if row.isStuck}
+													{@const waitId = `wait-${row.ns}-${row.name}`.replace(/[^a-z0-9-]/gi, '-')}
+													<span id={waitId} class="inline-flex cursor-help items-center gap-0.5 font-medium text-orange-600 dark:text-orange-400">
+														<ClockSolid class="h-3 w-3" />{compactSeconds(row.waitingSeconds)}
+													</span>
+												{:else if row.waitingCandidateVersion}
+													{@const waitId = `wait-${row.ns}-${row.name}`.replace(/[^a-z0-9-]/gi, '-')}
+													<span id={waitId} class="inline-flex cursor-help items-center text-gray-400 dark:text-gray-500" title="Waiting on gates">
+														<ClockSolid class="h-3 w-3" />
+													</span>
+												{/if}
+												{#if row.failedHCCount > 0}
+													<span class="inline-flex items-center gap-0.5 text-red-600 dark:text-red-400" title="{row.failedHCCount} failed health checks">
+														<HeartSolid class="h-3 w-3" />{row.failedHCCount}
+													</span>
+												{/if}
+												{#if row.upgradeCount > 0 && !row.isStuck && !row.waitingCandidateVersion}
+													<span class="inline-flex items-center gap-0.5 text-gray-400 dark:text-gray-500" title="{row.upgradeCount} pending upgrades">
+														<ArrowUpOutline class="h-3 w-3" />{row.upgradeCount}
+													</span>
+												{/if}
+												{#if row.age}
+													<span class="font-mono text-gray-400 dark:text-gray-500">{row.age}</span>
+												{/if}
+											</div>
 										</div>
 
-										<!-- Per-rollout timeline aligned within the group's time range — for spotting cross-deployment correlations -->
+										<!-- Subtle per-rollout timeline (light dots on a hairline) -->
 										{#if row.displayHistory.length > 0}
-											<div class="mt-2 pl-4">
-												<div class="relative h-2.5">
-													<!-- track -->
-													<div class="absolute inset-x-0 top-1 h-0.5 rounded-full bg-gray-200 dark:bg-gray-700/60"></div>
-													<!-- now marker -->
-													<span class="absolute top-0 h-2.5 w-px bg-gray-400 dark:bg-gray-500" style="right: 0; left: auto;"></span>
-													<!-- deploy markers -->
+											<div class="mt-2 pl-[18px]">
+												<div class="relative h-1.5">
+													<div class="absolute inset-x-0 top-[3px] h-px bg-gray-100 dark:bg-gray-700/40"></div>
 													{#each row.displayHistory as h}
 														{@const t = new Date(h.ts).getTime()}
 														{@const x = Math.min(100, Math.max(0, ((t - group.rangeMin) / group.rangeSpan) * 100))}
 														{@const b = STATUS_BADGE[h.status] ?? STATUS_BADGE['None']}
 														<span
-															class="absolute top-0 h-2.5 w-2.5 -translate-x-1/2 rounded-full ring-2 {b.sparkBg} {row.status === 'Failed' ? 'ring-red-50/40 dark:ring-red-900/10' : isRunning(row.status) ? 'ring-yellow-50/30 dark:ring-yellow-900/5' : 'ring-white dark:ring-gray-800'}"
+															class="absolute top-0 h-1.5 w-1.5 -translate-x-1/2 rounded-full {b.sparkBg}"
 															style="left: {x}%"
 															title="{h.version} · {h.status}"
 														></span>

--- a/frontend/src/lib/Rollouts.svelte
+++ b/frontend/src/lib/Rollouts.svelte
@@ -1,8 +1,9 @@
 <svelte:options runes={true} />
 
 <script lang="ts">
-	import type { Rollout } from '../types';
+	import type { Rollout, Environment } from '../types';
 	import { Alert, Badge, Popover } from 'flowbite-svelte';
+	import JoinedBadge from '$lib/components/JoinedBadge.svelte';
 	import {
 		SearchOutline,
 		ArrowUpOutline,
@@ -29,19 +30,48 @@
 	);
 
 	const rollouts = $derived<Rollout[]>(rolloutsQuery.data?.rollouts?.items || []);
+	const environments = $derived<Environment[]>(rolloutsQuery.data?.environments?.items || []);
+	const envByRollout = $derived.by(() => {
+		const m = new Map<string, Environment>();
+		for (const env of environments) {
+			const ns = env.metadata?.namespace || '';
+			const refName = env.spec?.rolloutRef?.name;
+			if (ns && refName) m.set(`${ns}/${refName}`, env);
+		}
+		return m;
+	});
 	const loading  = $derived(rolloutsQuery.isLoading);
 	const error    = $derived(
 		rolloutsQuery.isError ? (rolloutsQuery.error as Error).message || 'Unknown error' : null
 	);
 
+	function envForRollout(r: Rollout): Environment | undefined {
+		const ns = r.metadata?.namespace || '';
+		const name = r.metadata?.name || '';
+		return envByRollout.get(`${ns}/${name}`);
+	}
+
 	type GroupBy = 'namespace' | 'name' | 'environment';
+	const GROUP_BY_STORAGE_KEY = 'rollouts:groupBy';
+
+	function loadGroupBy(): GroupBy {
+		if (typeof window === 'undefined') return 'namespace';
+		const v = window.localStorage.getItem(GROUP_BY_STORAGE_KEY);
+		return v === 'name' || v === 'environment' || v === 'namespace' ? v : 'namespace';
+	}
 
 	let searchQuery   = $state('');
 	let statusFilters = $state<StatusKey[]>([]);
 	let envFilters    = $state<string[]>([]);
 	let nsFilters     = $state<string[]>([]);
-	let groupBy       = $state<GroupBy>('namespace');
+	let groupBy       = $state<GroupBy>(loadGroupBy());
 	let showFilters   = $state(false);
+
+	$effect(() => {
+		if (typeof window !== 'undefined') {
+			window.localStorage.setItem(GROUP_BY_STORAGE_KEY, groupBy);
+		}
+	});
 
 	const activeFilterCount = $derived(statusFilters.length + envFilters.length + nsFilters.length);
 	const uniqueNamespaces = $derived(
@@ -81,8 +111,8 @@
 	const uniqueEnvironments = $derived.by(() => {
 		const seen = new Map<string, string>();
 		rollouts.forEach((r) => {
-			const t = getRolloutEnvironmentTheme(r);
-			if (t?.label) seen.set(t.label.toLowerCase(), t.label);
+			const t = getRolloutEnvironmentTheme(r, envForRollout(r));
+			if (t?.environmentName) seen.set(t.environmentName.toLowerCase(), t.environmentName);
 		});
 		return [...seen.values()].sort();
 	});
@@ -112,6 +142,12 @@
 		displayHistory: HistoryDot[];           // history clipped to group context (set by groupedRows)
 		latestTs: number;                       // for sorting by recency
 		pinnedVersion: string | null;           // spec.wantedVersion when set — automated deploys paused
+		// Behind-lead info (set by behindInfoMap derivation; null if no siblings or this row IS the lead)
+		behindCount: number;                    // versions in lead.history not yet deployed here
+		behindOldestLagSec: number;             // oldest unpromoted version's current lag vs lead
+		behindThresholdSec: number;             // mean+stdev of historical promotion lags
+		isBehindSlow: boolean;                  // oldest unpromoted version's lag exceeds threshold
+		leadKey: string | null;                 // lead env label (preferred) or namespace
 	};
 
 	function buildRow(r: Rollout, n: Date): Row {
@@ -187,7 +223,7 @@
 			upgradeCount:            rcs.length,
 			failedHCCount:           latest?.failedHealthChecks?.length || 0,
 			bakeProgressPct,
-			theme:                   getRolloutEnvironmentTheme(r),
+			theme:                   getRolloutEnvironmentTheme(r, envForRollout(r)),
 			waitingCandidateVersion,
 			waitingSeconds,
 			stuckThresholdSec,
@@ -197,6 +233,11 @@
 			displayHistory:          history, // overwritten in groupedRows once we know group context
 			latestTs:                latest?.timestamp ? new Date(latest.timestamp).getTime() : 0,
 			pinnedVersion:           r.spec?.wantedVersion || null,
+			behindCount:             0,
+			behindOldestLagSec:      0,
+			behindThresholdSec:      0,
+			isBehindSlow:            false,
+			leadKey:                 null,
 		};
 	}
 
@@ -214,7 +255,63 @@
 
 	const allRows = $derived.by(() => {
 		const n = $now;
-		return rollouts.map((r) => buildRow(r, n));
+		const nowMs = n.getTime();
+		const rows = rollouts.map((r) => buildRow(r, n));
+
+		// Second pass: compute "behind lead" info per row, using same-named siblings as the comparison set.
+		// Threshold = mean + 1 stdev of HISTORICAL promotion lags (versions present in both this row and the lead),
+		// matching the same shape as the stuck heuristic so behaviour is comparable.
+		const byName = new Map<string, Row[]>();
+		for (const row of rows) {
+			const list = byName.get(row.name);
+			if (list) list.push(row); else byName.set(row.name, [row]);
+		}
+		for (const row of rows) {
+			const siblings = byName.get(row.name) || [];
+			if (siblings.length <= 1) continue;
+			// Lead = sibling with newest latest deploy
+			let lead = row;
+			for (const s of siblings) if (s.latestTs > lead.latestTs) lead = s;
+			if (lead === row || lead.history.length === 0) continue;
+
+			const myVersions = new Set(row.history.map((h) => h.version));
+			const leadByVersion = new Map<string, number>();
+			for (const h of lead.history) leadByVersion.set(h.version, new Date(h.ts).getTime());
+
+			// Historical promotion lags: versions that this row eventually deployed AFTER the lead did.
+			const histLags: number[] = [];
+			for (const h of row.history) {
+				const leadTs = leadByVersion.get(h.version);
+				if (leadTs === undefined) continue;
+				const myTs = new Date(h.ts).getTime();
+				if (myTs > leadTs) histLags.push((myTs - leadTs) / 1000);
+			}
+			let threshold = 7 * 86400;
+			if (histLags.length >= 3) {
+				const mean = histLags.reduce((a, b) => a + b, 0) / histLags.length;
+				const stdev = Math.sqrt(histLags.reduce((s, x) => s + (x - mean) ** 2, 0) / histLags.length);
+				threshold = Math.max(mean + stdev, 30 * 60);
+			} else if (histLags.length > 0) {
+				threshold = Math.max(Math.max(...histLags) * 2, 30 * 60);
+			}
+
+			// Unpromoted: versions in lead.history this row hasn't deployed yet.
+			let behindCount = 0;
+			let oldestLag = 0;
+			for (const h of lead.history) {
+				if (myVersions.has(h.version)) continue;
+				behindCount++;
+				const lag = Math.max(0, (nowMs - new Date(h.ts).getTime()) / 1000);
+				if (lag > oldestLag) oldestLag = lag;
+			}
+
+			row.behindCount = behindCount;
+			row.behindOldestLagSec = oldestLag;
+			row.behindThresholdSec = threshold;
+			row.isBehindSlow = behindCount > 0 && oldestLag > threshold;
+			row.leadKey = lead.theme?.environmentName ?? lead.ns;
+		}
+		return rows;
 	});
 
 	const filteredRollouts = $derived.by(() => {
@@ -222,7 +319,7 @@
 		return allRows.filter((row) => {
 			if (q && !row.name.toLowerCase().includes(q) && !row.ns.toLowerCase().includes(q)) return false;
 			if (nsFilters.length > 0  && !nsFilters.includes(row.ns)) return false;
-			if (envFilters.length > 0 && !envFilters.includes(row.theme?.label ?? '')) return false;
+			if (envFilters.length > 0 && !envFilters.includes(row.theme?.environmentName ?? '')) return false;
 			if (!matchesStatusFilter(row)) return false;
 			return true;
 		});
@@ -252,7 +349,7 @@
 
 	function groupKeyOf(row: Row, gb: GroupBy): { key: string; label: string; labelKind: Group['labelKind'] } {
 		if (gb === 'name')        return { key: row.name, label: row.name, labelKind: 'name' };
-		if (gb === 'environment') return { key: row.theme?.label ?? 'No environment', label: row.theme?.label ?? 'No environment', labelKind: 'environment' };
+		if (gb === 'environment') return { key: row.theme?.environmentName ?? 'No environment', label: row.theme?.environmentName ?? 'No environment', labelKind: 'environment' };
 		return { key: row.ns, label: row.ns, labelKind: 'namespace' };
 	}
 
@@ -346,7 +443,7 @@
 	const stuckTotal = $derived(statusCounts.stuck);
 
 	function envCount(env: string): number {
-		return rollouts.filter((r) => getRolloutEnvironmentTheme(r)?.label === env).length;
+		return rollouts.filter((r) => getRolloutEnvironmentTheme(r, envForRollout(r))?.environmentName === env).length;
 	}
 
 	type StatusKey = 'failed' | 'active' | 'stuck' | 'succeeded' | 'idle';
@@ -639,49 +736,39 @@
 		{:else}
 			<div class="grid grid-cols-1 gap-5 sm:grid-cols-2 xl:grid-cols-3">
 				{#each groupedRows as group}
-					{@const drift = groupBy === 'name' && group.versions.size > 1}
 					{@const groupHighlighted =
 						(group.labelKind === 'namespace' && nsFilters.includes(group.key)) ||
 						(group.labelKind === 'environment' && envFilters.includes(group.key))}
-					<section class="group/card overflow-hidden rounded-xl border bg-white shadow-sm transition-all hover:shadow-md dark:bg-gray-800
+					<section class="overflow-hidden rounded-lg border bg-white dark:bg-gray-800
 						{groupHighlighted ? 'border-blue-300 dark:border-blue-700' : 'border-gray-200 dark:border-gray-700'}"
 					>
-						<!-- Group header (calm, refined) -->
+						<!-- Group header -->
 						<button
 							type="button"
 							onclick={() => toggleGroupKey(group)}
 							aria-pressed={groupHighlighted}
-							class="flex w-full items-center justify-between gap-2 border-b border-gray-100 px-4 py-3 text-left transition-colors hover:bg-gray-50/80 dark:border-gray-700/60 dark:hover:bg-gray-700/30"
+							class="flex w-full items-center justify-between gap-2 border-b border-gray-100 px-4 py-2.5 text-left transition-colors hover:bg-gray-50 dark:border-gray-700/60 dark:hover:bg-gray-700/40"
 						>
-							<div class="flex min-w-0 items-center gap-2.5">
+							<div class="flex min-w-0 items-center gap-2">
 								<!-- Severity indicator — only when not healthy -->
 								{#if group.severity === 3}
-									<span class="relative flex h-2 w-2 shrink-0">
-										<span class="absolute inline-flex h-full w-full animate-ping rounded-full bg-red-400 opacity-50"></span>
-										<span class="relative inline-flex h-2 w-2 rounded-full bg-red-500" title="{group.failedCount} failed"></span>
-									</span>
+									<span class="h-1.5 w-1.5 shrink-0 rounded-full bg-red-500" title="{group.failedCount} failed"></span>
 								{:else if group.severity === 2}
-									<span class="h-2 w-2 shrink-0 rounded-full bg-orange-500" title="{group.stuckCount} stuck"></span>
+									<span class="h-1.5 w-1.5 shrink-0 rounded-full bg-orange-500" title="{group.stuckCount} stuck"></span>
 								{:else if group.severity === 1}
-									<span class="relative flex h-2 w-2 shrink-0">
-										<span class="absolute inline-flex h-full w-full animate-ping rounded-full bg-yellow-300 opacity-50"></span>
-										<span class="relative inline-flex h-2 w-2 rounded-full bg-yellow-400" title="{group.activeCount} active"></span>
-									</span>
+									<span class="h-1.5 w-1.5 shrink-0 rounded-full bg-yellow-400" title="{group.activeCount} active"></span>
 								{/if}
 								{#if group.labelKind === 'environment'}
 									<Badge color="dark" border rounded class="environment-theme-badge"
 										style={(group.rows[0]?.theme) ? getEnvironmentThemeStyle(group.rows[0].theme) : undefined}
 									>{group.label}</Badge>
 								{:else}
-									<h3 class="truncate text-[13px] tracking-tight
+									<h3 class="truncate text-xs
 										{group.labelKind === 'name' ? 'font-semibold text-gray-900 dark:text-white' : 'font-mono font-semibold text-gray-700 dark:text-gray-200'}
 										{groupHighlighted ? 'text-blue-600 dark:text-blue-400' : ''}"
 									>{group.label}</h3>
 								{/if}
-								<span class="shrink-0 rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium tabular-nums text-gray-500 dark:bg-gray-700/60 dark:text-gray-400">{group.rows.length}</span>
-								{#if drift}
-									<Badge color="orange" rounded class="text-[10px]" title="Versions differ across deployments">drift</Badge>
-								{/if}
+								<span class="shrink-0 text-[11px] tabular-nums text-gray-400 dark:text-gray-500">{group.rows.length}</span>
 							</div>
 							{#if groupHighlighted}
 								<CloseOutline class="h-3.5 w-3.5 text-blue-500" />
@@ -696,11 +783,8 @@
 									<a
 										href="/rollouts/{row.ns}/{row.name}"
 										style={row.theme ? getEnvironmentThemeStyle(row.theme) : undefined}
-										class="environment-theme-scope group/row relative block px-4 py-3 transition-colors hover:bg-gray-50/80 dark:hover:bg-gray-700/30"
+										class="environment-theme-scope relative block px-4 py-3 transition-colors hover:bg-gray-50 dark:hover:bg-gray-700/40"
 									>
-										<!-- Subtle hover indicator slides in from left -->
-										<span class="pointer-events-none absolute inset-y-2 left-0 w-0.5 origin-top scale-y-0 rounded-r-full bg-blue-400 transition-transform duration-200 group-hover/row:scale-y-100 dark:bg-blue-500"></span>
-
 										<!-- Line 1: dot + name + env -->
 										<div class="flex items-center gap-2.5">
 											<span class="relative flex h-2 w-2 shrink-0">
@@ -710,72 +794,90 @@
 												<span class="relative inline-flex h-2 w-2 rounded-full {badge.dot}"></span>
 											</span>
 											{#if groupBy === 'name'}
-												<h4 class="min-w-0 flex-1 truncate font-mono text-[13px] text-gray-700 transition-colors group-hover/row:text-gray-900 dark:text-gray-300 dark:group-hover/row:text-white">{row.ns}</h4>
-												{#if row.theme}
-													<Badge color="dark" border rounded class="environment-theme-badge shrink-0">{row.theme.label}</Badge>
+												<h4 class="min-w-0 flex-1 truncate font-mono text-[12.5px] text-gray-700 dark:text-gray-300">{row.ns}</h4>
+												{#if row.theme?.environmentName}
+													<JoinedBadge
+														label="Environment"
+														value={row.theme.environmentName}
+														valueColor="gray"
+														containerClass="environment-theme-scope shrink-0"
+														containerStyle={getEnvironmentThemeStyle(row.theme)}
+														labelPlainBorder
+														valueClass="environment-theme-badge"
+													/>
 												{/if}
 											{:else if groupBy === 'environment'}
-												<h4 class="min-w-0 flex-1 truncate text-[14px] font-semibold tracking-tight text-gray-900 dark:text-white">{row.name}</h4>
+												<h4 class="min-w-0 flex-1 truncate text-sm font-semibold text-gray-900 dark:text-white">{row.name}</h4>
 												<span class="shrink-0 truncate font-mono text-[11px] text-gray-400 dark:text-gray-500">{row.ns}</span>
 											{:else}
-												<h4 class="min-w-0 flex-1 truncate text-[14px] font-semibold tracking-tight text-gray-900 dark:text-white">{row.name}</h4>
-												{#if row.theme}
-													<Badge color="dark" border rounded class="environment-theme-badge shrink-0">{row.theme.label}</Badge>
+												<h4 class="min-w-0 flex-1 truncate text-sm font-semibold text-gray-900 dark:text-white">{row.name}</h4>
+												{#if row.theme?.environmentName}
+													<JoinedBadge
+														label="Environment"
+														value={row.theme.environmentName}
+														valueColor="gray"
+														containerClass="environment-theme-scope shrink-0"
+														containerStyle={getEnvironmentThemeStyle(row.theme)}
+														labelPlainBorder
+														valueClass="environment-theme-badge"
+													/>
 												{/if}
 											{/if}
 										</div>
 
-										<!-- Line 2: minimal meta — version, age, and ONLY non-healthy signals -->
-										<div class="mt-1 flex items-center gap-x-2 pl-[18px] text-[11px] text-gray-500 dark:text-gray-500">
+										<!-- Line 2: meta — wraps naturally on narrow screens -->
+										<div class="mt-1 flex flex-wrap items-center gap-x-2.5 gap-y-1 pl-[18px] text-[11px] text-gray-500 dark:text-gray-500">
 											<!-- Status label only when not Healthy/Idle (those are implied by the dot) -->
 											{#if row.status === 'Failed'}
 												<span class="shrink-0 font-medium text-red-600 dark:text-red-400">Failed</span>
-												<span class="text-gray-300 dark:text-gray-700">·</span>
 											{:else if isRunning(row.status)}
 												<span class="shrink-0 font-medium text-yellow-700 dark:text-yellow-400">
 													{badge.label}{#if row.bakeProgressPct !== null}&nbsp;{Math.round(row.bakeProgressPct)}%{/if}
 												</span>
-												<span class="text-gray-300 dark:text-gray-700">·</span>
 											{/if}
 
 											{#if row.version}
-												<span class="min-w-0 truncate font-mono">{row.version}</span>
+												<span class="min-w-0 max-w-full truncate font-mono">{row.version}</span>
 											{:else}
 												<span class="text-gray-300 dark:text-gray-700">no version</span>
 											{/if}
 
-											<!-- Trailing signals (right-aligned, icon-only) -->
-											<div class="ml-auto flex shrink-0 items-center gap-2 tabular-nums">
-												{#if row.pinnedVersion}
-													<span class="inline-flex items-center text-orange-500 dark:text-orange-400" title="Pinned to {row.pinnedVersion}">
-														<PauseSolid class="h-3 w-3" />
-													</span>
-												{/if}
-												{#if row.isStuck}
-													{@const waitId = `wait-${row.ns}-${row.name}`.replace(/[^a-z0-9-]/gi, '-')}
-													<span id={waitId} class="inline-flex cursor-help items-center gap-0.5 font-medium text-orange-600 dark:text-orange-400">
-														<ClockSolid class="h-3 w-3" />{compactSeconds(row.waitingSeconds)}
-													</span>
-												{:else if row.waitingCandidateVersion}
-													{@const waitId = `wait-${row.ns}-${row.name}`.replace(/[^a-z0-9-]/gi, '-')}
-													<span id={waitId} class="inline-flex cursor-help items-center text-gray-400 dark:text-gray-500" title="Waiting on gates">
-														<ClockSolid class="h-3 w-3" />
-													</span>
-												{/if}
-												{#if row.failedHCCount > 0}
-													<span class="inline-flex items-center gap-0.5 text-red-600 dark:text-red-400" title="{row.failedHCCount} failed health checks">
-														<HeartSolid class="h-3 w-3" />{row.failedHCCount}
-													</span>
-												{/if}
-												{#if row.upgradeCount > 0 && !row.isStuck && !row.waitingCandidateVersion}
-													<span class="inline-flex items-center gap-0.5 text-gray-400 dark:text-gray-500" title="{row.upgradeCount} pending upgrades">
-														<ArrowUpOutline class="h-3 w-3" />{row.upgradeCount}
-													</span>
-												{/if}
-												{#if row.age}
-													<span class="font-mono text-gray-400 dark:text-gray-500">{row.age}</span>
-												{/if}
-											</div>
+											<!-- Signals — flow inline, wrap on narrow viewports -->
+											{#if row.pinnedVersion}
+												<span class="inline-flex shrink-0 items-center gap-1 text-orange-600 dark:text-orange-400" title="Pinned to {row.pinnedVersion} — automated deploys are paused until the pin is cleared">
+													<PauseSolid class="h-3 w-3" />Pinned
+												</span>
+											{/if}
+											{#if row.isStuck}
+												{@const waitId = `wait-${row.ns}-${row.name}`.replace(/[^a-z0-9-]/gi, '-')}
+												<span id={waitId} class="inline-flex shrink-0 cursor-help items-center gap-1 font-medium text-orange-600 dark:text-orange-400">
+													<ClockSolid class="h-3 w-3" />stuck {compactSeconds(row.waitingSeconds)}
+												</span>
+											{:else if row.upgradeCount > 0}
+												<span class="inline-flex shrink-0 items-center gap-1 text-orange-600 dark:text-orange-400" title="{row.upgradeCount} {row.upgradeCount === 1 ? 'upgrade' : 'upgrades'} available">
+													<ArrowUpOutline class="h-3 w-3" />{row.upgradeCount} {row.upgradeCount === 1 ? 'upgrade' : 'upgrades'}
+												</span>
+											{/if}
+											{#if row.failedHCCount > 0}
+												<span class="inline-flex shrink-0 items-center gap-1 text-red-600 dark:text-red-400" title="{row.failedHCCount} failed health check{row.failedHCCount === 1 ? '' : 's'}">
+													<HeartSolid class="h-3 w-3" />{row.failedHCCount} unhealthy
+												</span>
+											{/if}
+											{#if row.behindCount > 0}
+												{@const behindId = `behind-${row.ns}-${row.name}`.replace(/[^a-z0-9-]/gi, '-')}
+												<span
+													id={behindId}
+													class="inline-flex shrink-0 cursor-help items-center gap-1
+														{row.isBehindSlow ? 'font-medium text-orange-600 dark:text-orange-400' : 'text-gray-500 dark:text-gray-500'}"
+												>
+													<ChevronDownOutline class="h-3 w-3" />
+													{row.behindCount} behind {row.leadKey}{#if row.isBehindSlow}&nbsp;·&nbsp;{compactSeconds(row.behindOldestLagSec)}{/if}
+													<QuestionCircleOutline class="ml-0.5 h-3 w-3 opacity-60" />
+												</span>
+											{/if}
+											{#if row.age}
+												<span class="ml-auto shrink-0 font-mono text-gray-400 dark:text-gray-500">{row.age}</span>
+											{/if}
 										</div>
 
 										<!-- Subtle per-rollout deploy timeline -->
@@ -806,14 +908,49 @@
 										{/if}
 									</a>
 
-									{#if row.isStuck || row.waitingCandidateVersion}
+									{#if row.behindCount > 0}
+										{@const behindId = `behind-${row.ns}-${row.name}`.replace(/[^a-z0-9-]/gi, '-')}
+										<Popover triggeredBy={`#${behindId}`} class="max-w-sm">
+											<div class="p-3">
+												<div class="mb-2 flex items-center gap-2">
+													<ChevronDownOutline class="h-4 w-4 {row.isBehindSlow ? 'text-orange-500' : 'text-gray-400'}" />
+													<h4 class="text-sm font-semibold text-gray-900 dark:text-white">
+														{row.isBehindSlow ? 'Slow promotion' : 'Behind lead'}
+													</h4>
+												</div>
+												<dl class="space-y-1 text-xs text-gray-600 dark:text-gray-300">
+													<div class="flex justify-between gap-3">
+														<dt class="text-gray-500 dark:text-gray-400">Lead</dt>
+														<dd class="truncate font-mono">{row.leadKey}</dd>
+													</div>
+													<div class="flex justify-between gap-3">
+														<dt class="text-gray-500 dark:text-gray-400">Versions behind</dt>
+														<dd class="tabular-nums">{row.behindCount}</dd>
+													</div>
+													<div class="flex justify-between gap-3">
+														<dt class="text-gray-500 dark:text-gray-400">Oldest unpromoted lag</dt>
+														<dd class="font-mono tabular-nums {row.isBehindSlow ? 'font-semibold text-orange-600 dark:text-orange-400' : ''}">{compactSeconds(row.behindOldestLagSec)}</dd>
+													</div>
+													<div class="flex justify-between gap-3">
+														<dt class="text-gray-500 dark:text-gray-400">Slow threshold</dt>
+														<dd class="font-mono tabular-nums">{compactSeconds(row.behindThresholdSec)}</dd>
+													</div>
+												</dl>
+												<p class="mt-2 border-t border-gray-100 pt-2 text-[11px] leading-relaxed text-gray-500 dark:border-gray-700 dark:text-gray-400">
+													Threshold = mean + 1·stdev of historical promotion lag (per matching version that landed in both this rollout and the lead). With &lt;3 samples, falls back to 2× max historical lag, then to 7 days.
+												</p>
+											</div>
+										</Popover>
+									{/if}
+
+									{#if row.isStuck}
 										{@const waitId = `wait-${row.ns}-${row.name}`.replace(/[^a-z0-9-]/gi, '-')}
 										<Popover triggeredBy={`#${waitId}`} class="max-w-sm">
 											<div class="p-3">
 												<div class="mb-2 flex items-center gap-2">
-													<ClockSolid class="h-4 w-4 {row.isStuck ? 'text-orange-500' : 'text-gray-400'}" />
+													<ClockSolid class="h-4 w-4 text-orange-500" />
 													<h4 class="text-sm font-semibold text-gray-900 dark:text-white">
-														{row.isStuck ? 'Stuck on gates' : 'Waiting on gates'}
+														Stuck on gates
 													</h4>
 												</div>
 												<dl class="space-y-1 text-xs text-gray-600 dark:text-gray-300">

--- a/frontend/src/lib/Rollouts.svelte
+++ b/frontend/src/lib/Rollouts.svelte
@@ -2,13 +2,26 @@
 
 <script lang="ts">
 	import type { Rollout } from '../types';
-	import { Alert, Badge, Sidebar, SidebarGroup } from 'flowbite-svelte';
-	import { SearchOutline, ArrowUpOutline, HeartSolid } from 'flowbite-svelte-icons';
+	import { Alert, Badge, Popover } from 'flowbite-svelte';
+	import {
+		SearchOutline,
+		ArrowUpOutline,
+		HeartSolid,
+		CloseOutline,
+		CheckCircleSolid,
+		ClockSolid,
+		FilterOutline,
+		FilterSolid,
+		ChevronDownOutline,
+		ChevronUpOutline,
+		QuestionCircleOutline,
+		PauseSolid,
+	} from 'flowbite-svelte-icons';
+	import { slide } from 'svelte/transition';
 	import { getDisplayVersion } from '$lib/utils';
 	import { now } from '$lib/stores/time';
 	import { createQuery } from '@tanstack/svelte-query';
 	import { rolloutsListQueryOptions } from '$lib/api/rollouts';
-	import BakeStatusIcon from '$lib/components/BakeStatusIcon.svelte';
 	import { getEnvironmentThemeStyle, getRolloutEnvironmentTheme } from '$lib/environment-theme';
 
 	const rolloutsQuery = createQuery(() =>
@@ -21,33 +34,30 @@
 		rolloutsQuery.isError ? (rolloutsQuery.error as Error).message || 'Unknown error' : null
 	);
 
-	let searchQuery     = $state('');
-	let namespaceFilter = $state('all');
-	let statusFilter    = $state('all');
+	type GroupBy = 'namespace' | 'name' | 'environment';
 
+	let searchQuery   = $state('');
+	let statusFilters = $state<StatusKey[]>([]);
+	let envFilters    = $state<string[]>([]);
+	let nsFilters     = $state<string[]>([]);
+	let groupBy       = $state<GroupBy>('namespace');
+	let showFilters   = $state(false);
+
+	const activeFilterCount = $derived(statusFilters.length + envFilters.length + nsFilters.length);
 	const uniqueNamespaces = $derived(
 		[...new Set(rollouts.map((r) => r.metadata?.namespace || 'default'))].sort()
 	);
 
-	const STATUS_TEXT: Record<string, string> = {
-		Succeeded:  'text-green-600 dark:text-green-400',
-		Failed:     'text-red-600 dark:text-red-400',
-		InProgress: 'text-yellow-600 dark:text-yellow-400',
-		Deploying:  'text-blue-600 dark:text-blue-400',
-		Cancelled:  'text-gray-500 dark:text-gray-400',
-		None:       'text-gray-400 dark:text-gray-500',
-	};
-
-	const ACTIVE_LABEL: Record<string, string> = {
-		InProgress: 'Baking',
-		Deploying:  'Deploying',
-	};
+	function nsCount(ns: string): number {
+		return rollouts.filter((r) => (r.metadata?.namespace || 'default') === ns).length;
+	}
 
 	function getBakeStatus(r: Rollout): string {
 		return r.status?.history?.[0]?.bakeStatus || 'None';
 	}
 
-	function compactTime(timestamp: string, n: Date): string {
+	function compactTime(timestamp: string | undefined, n: Date): string | null {
+		if (!timestamp) return null;
 		const s = Math.floor((n.getTime() - new Date(timestamp).getTime()) / 1000);
 		if (s < 60)    return `${s}s`;
 		if (s < 3600)  return `${Math.floor(s / 60)}m`;
@@ -68,286 +78,792 @@
 		}
 	}
 
+	const uniqueEnvironments = $derived.by(() => {
+		const seen = new Map<string, string>();
+		rollouts.forEach((r) => {
+			const t = getRolloutEnvironmentTheme(r);
+			if (t?.label) seen.set(t.label.toLowerCase(), t.label);
+		});
+		return [...seen.values()].sort();
+	});
+
 	const STATUS_SORT: Record<string, number> = {
 		Failed: 0, InProgress: 1, Deploying: 2, None: 3, Cancelled: 4, Succeeded: 5
 	};
 
-	const filteredRolloutsByNamespace = $derived.by(() => {
-		const filtered = rollouts
-			.filter((r) => {
-				const ns   = r.metadata?.namespace || 'default';
-				const name = r.metadata?.name || '';
-				const st   = getBakeStatus(r);
-				const matchesSearch = searchQuery === '' ||
-					name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-					ns.toLowerCase().includes(searchQuery.toLowerCase());
-				const matchesNs = namespaceFilter === 'all' || ns === namespaceFilter;
-				const matchesStatus =
-					statusFilter === 'all'       ||
-					(statusFilter === 'active'    && (st === 'InProgress' || st === 'Deploying')) ||
-					(statusFilter === 'failed'    && st === 'Failed') ||
-					(statusFilter === 'succeeded' && st === 'Succeeded') ||
-					(statusFilter === 'idle'      && st === 'None');
-				return matchesSearch && matchesNs && matchesStatus;
-			})
-			.sort((a, b) => {
-				const diff = (STATUS_SORT[getBakeStatus(a)] ?? 3) - (STATUS_SORT[getBakeStatus(b)] ?? 3);
-				return diff !== 0 ? diff : (a.metadata?.name || '').localeCompare(b.metadata?.name || '');
-			});
+	type HistoryDot = { status: string; ts: string; version: string };
 
-		const grouped: Record<string, Rollout[]> = {};
-		filtered.forEach((r) => {
-			const ns = r.metadata?.namespace || 'default';
-			if (!grouped[ns]) grouped[ns] = [];
-			grouped[ns].push(r);
+	type Row = {
+		ns: string;
+		name: string;
+		status: string;
+		version: string | null;
+		age: string | null;
+		upgradeCount: number;
+		failedHCCount: number;
+		bakeProgressPct: number | null;
+		theme: ReturnType<typeof getRolloutEnvironmentTheme>;
+		waitingCandidateVersion: string | null; // oldest non-deployed, non-gated candidate
+		waitingSeconds: number;                 // how long the oldest waiting candidate has been waiting
+		stuckThresholdSec: number;              // when waitingSeconds exceeds this, considered "stuck"
+		isStuck: boolean;                       // waiting > historical norm
+		gatesBlocking: number;                  // number of failing gates
+		history: HistoryDot[];                  // recent deploy outcomes (oldest first)
+		displayHistory: HistoryDot[];           // history clipped to group context (set by groupedRows)
+		latestTs: number;                       // for sorting by recency
+		pinnedVersion: string | null;           // spec.wantedVersion when set — automated deploys paused
+	};
+
+	function buildRow(r: Rollout, n: Date): Row {
+		const latest = r.status?.history?.[0];
+		const status = getBakeStatus(r);
+		let bakeProgressPct: number | null = null;
+		if (status === 'InProgress' && latest?.bakeStartTime && r.spec?.bakeTime) {
+			const elapsed = n.getTime() - new Date(latest.bakeStartTime).getTime();
+			const total = parseDuration(r.spec.bakeTime);
+			if (total > 0) bakeProgressPct = Math.min(100, Math.max(0, (elapsed / total) * 100));
+		}
+
+		// Find oldest waiting release candidate (not deployed, not in gated set)
+		const rcs = r.status?.releaseCandidates ?? [];
+		const gated = new Set((r.status?.gatedReleaseCandidates ?? []).map((g) => g.tag ?? g.version ?? ''));
+		const deployedVersion = latest?.version?.version ?? latest?.version?.tag ?? '';
+		let waitingCandidateVersion: string | null = null;
+		let waitingSeconds = 0;
+		for (const rc of rcs) {
+			const id = rc.tag ?? rc.version ?? '';
+			if (!id || id === deployedVersion) continue;
+			if (gated.size > 0 && gated.has(id)) continue;
+			if (rc.created) {
+				const secs = Math.floor((n.getTime() - new Date(rc.created).getTime()) / 1000);
+				if (secs > waitingSeconds) {
+					waitingSeconds = secs;
+					waitingCandidateVersion = id;
+				}
+			} else if (!waitingCandidateVersion) {
+				waitingCandidateVersion = id;
+			}
+		}
+
+		// Compute historical wait-time stats: how long versions usually sat before deploy.
+		const histWaits: number[] = [];
+		for (const h of r.status?.history ?? []) {
+			if (h.version?.created && h.timestamp) {
+				const wait = (new Date(h.timestamp).getTime() - new Date(h.version.created).getTime()) / 1000;
+				if (wait > 0) histWaits.push(wait);
+			}
+		}
+		// Threshold = mean + 1 stdev of historical waits, with sensible fallbacks.
+		// Floor of 30 min so a flaky single-sample doesn't trigger 'stuck' instantly.
+		let stuckThresholdSec = 7 * 86400; // default: 7 days when no usable history
+		if (histWaits.length >= 3) {
+			const mean = histWaits.reduce((a, b) => a + b, 0) / histWaits.length;
+			const variance = histWaits.reduce((s, x) => s + (x - mean) ** 2, 0) / histWaits.length;
+			const stdev = Math.sqrt(variance);
+			stuckThresholdSec = Math.max(mean + stdev, 30 * 60);
+		} else if (histWaits.length > 0) {
+			// Small sample: 2x the max historical wait, with 30-min floor
+			stuckThresholdSec = Math.max(Math.max(...histWaits) * 2, 30 * 60);
+		}
+		const isStuck = waitingCandidateVersion !== null && waitingSeconds > stuckThresholdSec;
+
+		const gatesBlocking = (r.status?.gates ?? []).filter((g) => g.passing === false).length;
+
+		const history: HistoryDot[] = (r.status?.history ?? [])
+			.slice(0, 12)
+			.map((h) => ({
+				status: h.bakeStatus ?? 'None',
+				ts: h.timestamp,
+				version: h.version?.version ?? h.version?.tag ?? '',
+			}))
+			.reverse(); // oldest left, newest right
+
+		return {
+			ns:                      r.metadata?.namespace || 'default',
+			name:                    r.metadata?.name || '',
+			status,
+			version:                 latest?.version ? getDisplayVersion(latest.version) : null,
+			age:                     compactTime(latest?.timestamp, n),
+			upgradeCount:            rcs.length,
+			failedHCCount:           latest?.failedHealthChecks?.length || 0,
+			bakeProgressPct,
+			theme:                   getRolloutEnvironmentTheme(r),
+			waitingCandidateVersion,
+			waitingSeconds,
+			stuckThresholdSec,
+			isStuck,
+			gatesBlocking,
+			history,
+			displayHistory:          history, // overwritten in groupedRows once we know group context
+			latestTs:                latest?.timestamp ? new Date(latest.timestamp).getTime() : 0,
+			pinnedVersion:           r.spec?.wantedVersion || null,
+		};
+	}
+
+	function matchesStatusFilter(row: Row): boolean {
+		if (statusFilters.length === 0) return true;
+		return statusFilters.some((k) => {
+			if (k === 'failed')    return row.status === 'Failed';
+			if (k === 'active')    return row.status === 'InProgress' || row.status === 'Deploying';
+			if (k === 'stuck')     return row.isStuck;
+			if (k === 'succeeded') return row.status === 'Succeeded';
+			if (k === 'idle')      return row.status === 'None';
+			return false;
 		});
-		return Object.keys(grouped).sort().map((ns) => ({ ns, rollouts: grouped[ns] }));
+	}
+
+	const allRows = $derived.by(() => {
+		const n = $now;
+		return rollouts.map((r) => buildRow(r, n));
 	});
 
-	const totalFiltered = $derived(
-		filteredRolloutsByNamespace.reduce((s, g) => s + g.rollouts.length, 0)
-	);
+	const filteredRollouts = $derived.by(() => {
+		const q = searchQuery.trim().toLowerCase();
+		return allRows.filter((row) => {
+			if (q && !row.name.toLowerCase().includes(q) && !row.ns.toLowerCase().includes(q)) return false;
+			if (nsFilters.length > 0  && !nsFilters.includes(row.ns)) return false;
+			if (envFilters.length > 0 && !envFilters.includes(row.theme?.label ?? '')) return false;
+			if (!matchesStatusFilter(row)) return false;
+			return true;
+		});
+	});
+
+	function compactSeconds(s: number): string {
+		if (s < 60)    return `${s}s`;
+		if (s < 3600)  return `${Math.floor(s / 60)}m`;
+		if (s < 86400) return `${Math.floor(s / 3600)}h`;
+		return `${Math.floor(s / 86400)}d`;
+	}
+
+	type Group = {
+		key: string;
+		label: string;
+		labelKind: 'namespace' | 'name' | 'environment';
+		rows: Row[];
+		failedCount: number;
+		activeCount: number;
+		stuckCount: number;
+		severity: number;          // 0 healthy, 1 active, 2 stuck, 3 failed
+		versions: Set<string>;     // for drift detection when grouping by name
+		rangeMin: number;          // earliest history ts across the group (ms)
+		rangeMax: number;          // latest history ts (ms) or 'now'
+		rangeSpan: number;         // max - min (>=1)
+	};
+
+	function groupKeyOf(row: Row, gb: GroupBy): { key: string; label: string; labelKind: Group['labelKind'] } {
+		if (gb === 'name')        return { key: row.name, label: row.name, labelKind: 'name' };
+		if (gb === 'environment') return { key: row.theme?.label ?? 'No environment', label: row.theme?.label ?? 'No environment', labelKind: 'environment' };
+		return { key: row.ns, label: row.ns, labelKind: 'namespace' };
+	}
+
+	const groupedRows = $derived.by<Group[]>(() => {
+		const nowMs = $now.getTime();
+		const groups: Record<string, Group> = {};
+		for (const row of filteredRollouts) {
+			const { key, label, labelKind } = groupKeyOf(row, groupBy);
+			let g = groups[key];
+			if (!g) {
+				g = groups[key] = { key, label, labelKind, rows: [], failedCount: 0, activeCount: 0, stuckCount: 0, severity: 0, versions: new Set(), rangeMin: Infinity, rangeMax: -Infinity, rangeSpan: 1 };
+			}
+			g.rows.push(row);
+			if (row.status === 'Failed') g.failedCount++;
+			if (row.status === 'InProgress' || row.status === 'Deploying') g.activeCount++;
+			if (row.isStuck) g.stuckCount++;
+			if (row.version) g.versions.add(row.version);
+			for (const h of row.history) {
+				const t = new Date(h.ts).getTime();
+				if (t < g.rangeMin) g.rangeMin = t;
+				if (t > g.rangeMax) g.rangeMax = t;
+			}
+		}
+		for (const g of Object.values(groups)) {
+			g.rows.sort((a, b) => {
+				const d = (STATUS_SORT[a.status] ?? 3) - (STATUS_SORT[b.status] ?? 3);
+				return d !== 0 ? d : a.name.localeCompare(b.name);
+			});
+			g.severity =
+				g.failedCount > 0 ? 3 :
+				g.stuckCount  > 0 ? 2 :
+				g.activeCount > 0 ? 1 : 0;
+
+			// Clip per-rollout history so timelines only go back as far as
+			// "the deploy immediately before the group's oldest CURRENT version".
+			// History older than that predates everyone's current state and just adds noise.
+			const currentTsList = g.rows.map((r) => (r.history.length > 0 ? new Date(r.history[r.history.length - 1].ts).getTime() : Infinity));
+			const oldestCurrentTs = Math.min(...currentTsList);
+			let clippedMinTs = Infinity;
+			for (const r of g.rows) {
+				if (r.history.length === 0) { r.displayHistory = []; continue; }
+				// Keep all entries >= oldestCurrentTs plus the single most recent entry < oldestCurrentTs (the "minus 1" anchor)
+				const kept: HistoryDot[] = [];
+				let predecessor: HistoryDot | null = null;
+				for (const h of r.history) {
+					const t = new Date(h.ts).getTime();
+					if (t >= oldestCurrentTs) {
+						kept.push(h);
+					} else if (!predecessor || new Date(predecessor.ts).getTime() < t) {
+						predecessor = h;
+					}
+				}
+				if (predecessor) kept.unshift(predecessor);
+				r.displayHistory = kept;
+				for (const h of kept) {
+					const t = new Date(h.ts).getTime();
+					if (t < clippedMinTs) clippedMinTs = t;
+				}
+			}
+
+			// Range: clipped min → now (so latest deploys land near the right edge, not pinned to it)
+			if (clippedMinTs === Infinity) {
+				g.rangeMin = nowMs - 86400000;
+				g.rangeMax = nowMs;
+			} else {
+				g.rangeMin = clippedMinTs;
+				g.rangeMax = nowMs;
+			}
+			g.rangeSpan = Math.max(1, g.rangeMax - g.rangeMin);
+		}
+		return Object.values(groups).sort((a, b) => {
+			if (b.severity !== a.severity) return b.severity - a.severity;
+			return a.label.localeCompare(b.label);
+		});
+	});
+
+	const totalFiltered = $derived(filteredRollouts.length);
 
 	const statusCounts = $derived.by(() => {
-		const c = { active: 0, failed: 0, succeeded: 0, idle: 0 };
-		rollouts.forEach((r) => {
-			const st = getBakeStatus(r);
-			if (st === 'InProgress' || st === 'Deploying') c.active++;
-			else if (st === 'Failed')    c.failed++;
-			else if (st === 'Succeeded') c.succeeded++;
-			else if (st === 'None')      c.idle++;
+		const c = { active: 0, failed: 0, stuck: 0, succeeded: 0, idle: 0 };
+		allRows.forEach((row) => {
+			if (row.status === 'InProgress' || row.status === 'Deploying') c.active++;
+			else if (row.status === 'Failed')    c.failed++;
+			else if (row.status === 'Succeeded') c.succeeded++;
+			else if (row.status === 'None')      c.idle++;
+			if (row.isStuck)                     c.stuck++;
 		});
 		return c;
 	});
 
-	// Flowbite SidebarItem-compatible active/inactive classes
-	function sidebarItemClass(active: boolean) {
-		return `flex w-full items-center justify-between rounded-lg px-3 py-2 text-sm text-left transition-colors ${
-			active
-				? 'bg-gray-100 font-semibold text-gray-900 dark:bg-gray-700 dark:text-white'
-				: 'text-gray-600 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white'
-		}`;
+	const stuckTotal = $derived(statusCounts.stuck);
+
+	function envCount(env: string): number {
+		return rollouts.filter((r) => getRolloutEnvironmentTheme(r)?.label === env).length;
 	}
+
+	type StatusKey = 'failed' | 'active' | 'stuck' | 'succeeded' | 'idle';
+
+	const STATUS_META: Record<StatusKey, { label: string; color: 'red' | 'yellow' | 'green' | 'gray' | 'orange'; dot: string; help: string }> = {
+		failed:    { label: 'Failed',  color: 'red',    dot: 'bg-red-500',                    help: 'Bake or health checks failed for the last deploy' },
+		active:    { label: 'Active',  color: 'yellow', dot: 'bg-yellow-400',                 help: 'A deploy is currently baking or rolling out' },
+		stuck:     { label: 'Stuck',   color: 'orange', dot: 'bg-orange-500',                 help: 'A waiting candidate has exceeded the historical wait-time norm (mean + 1 stdev)' },
+		succeeded: { label: 'Healthy', color: 'green',  dot: 'bg-green-500',                  help: 'Last deploy succeeded; no pending upgrades blocked' },
+		idle:      { label: 'Idle',    color: 'gray',   dot: 'bg-gray-400 dark:bg-gray-600',  help: 'No deploys have run yet (no history)' },
+	};
+	const STATUS_FILTER_KEYS: StatusKey[] = ['failed', 'active', 'stuck', 'succeeded', 'idle'];
+
+	const STATUS_BADGE: Record<string, { color: 'green' | 'red' | 'yellow' | 'blue' | 'gray'; label: string; dot: string; sparkBg: string }> = {
+		Succeeded:  { color: 'green',  label: 'Healthy',   dot: 'bg-green-500',  sparkBg: 'bg-green-500' },
+		Failed:     { color: 'red',    label: 'Failed',    dot: 'bg-red-500',    sparkBg: 'bg-red-500' },
+		InProgress: { color: 'yellow', label: 'Baking',    dot: 'bg-yellow-400', sparkBg: 'bg-yellow-400' },
+		Deploying:  { color: 'blue',   label: 'Deploying', dot: 'bg-blue-500',   sparkBg: 'bg-blue-500' },
+		Cancelled:  { color: 'gray',   label: 'Cancelled', dot: 'bg-gray-400',   sparkBg: 'bg-gray-400' },
+		None:       { color: 'gray',   label: 'Idle',      dot: 'bg-gray-400 dark:bg-gray-600', sparkBg: 'bg-gray-300 dark:bg-gray-600' },
+	};
+
+	function isRunning(s: string) { return s === 'InProgress' || s === 'Deploying'; }
+
+	function toggleStatus(k: StatusKey) {
+		statusFilters = statusFilters.includes(k) ? statusFilters.filter((x) => x !== k) : [...statusFilters, k];
+	}
+	function toggleEnv(env: string) {
+		envFilters = envFilters.includes(env) ? envFilters.filter((x) => x !== env) : [...envFilters, env];
+	}
+	function toggleNs(ns: string) {
+		nsFilters = nsFilters.includes(ns) ? nsFilters.filter((x) => x !== ns) : [...nsFilters, ns];
+	}
+	function toggleGroupKey(g: Group) {
+		// Clicking a group header toggles a filter using the appropriate filter set
+		if (g.labelKind === 'namespace') toggleNs(g.key);
+		else if (g.labelKind === 'environment') envFilters = envFilters.includes(g.key) ? envFilters.filter((x) => x !== g.key) : [...envFilters, g.key];
+		else searchQuery = searchQuery === g.key ? '' : g.key;
+	}
+
+	const GROUP_OPTIONS: { value: GroupBy; label: string }[] = [
+		{ value: 'namespace',   label: 'Namespace' },
+		{ value: 'name',        label: 'App' },
+		{ value: 'environment', label: 'Environment' },
+	];
 </script>
 
-<div class="flex h-full overflow-hidden">
+<div class="flex min-h-full flex-col bg-gray-50/40 dark:bg-gray-900/30">
 
-	<!-- ── Sidebar (desktop only) ── -->
-	<div class="hidden lg:block">
-		<Sidebar class="h-full border-r border-gray-200 dark:border-gray-700" position="static">
-			<div class="flex flex-col gap-4 px-3 py-4">
-
-				<!-- Search -->
-				<div class="relative">
-					<SearchOutline class="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-gray-400" />
-					<input
-						type="search"
-						placeholder="Search…"
-						bind:value={searchQuery}
-						class="w-full rounded-md border border-gray-200 bg-gray-50 py-1.5 pl-8 pr-2 text-sm text-gray-900 placeholder-gray-400 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white"
-					/>
-				</div>
-
-				<!-- Status filter group -->
-				<SidebarGroup>
-					<p class="mb-1 px-3 text-[11px] font-semibold uppercase tracking-widest text-gray-400 dark:text-gray-500">Status</p>
-					<button onclick={() => (statusFilter = 'all')} class={sidebarItemClass(statusFilter === 'all')}>
-						All
-						<span class="text-xs tabular-nums text-gray-400 dark:text-gray-500">{rollouts.length}</span>
-					</button>
-					<button onclick={() => (statusFilter = 'active')} class={sidebarItemClass(statusFilter === 'active')}>
-						<span class="flex items-center gap-2"><span class="h-2 w-2 rounded-full bg-yellow-400"></span>Active</span>
-						<span class="text-xs tabular-nums {statusCounts.active > 0 ? 'text-gray-500 dark:text-gray-400' : 'text-gray-300 dark:text-gray-600'}">{statusCounts.active}</span>
-					</button>
-					<button onclick={() => (statusFilter = 'failed')} class={sidebarItemClass(statusFilter === 'failed')}>
-						<span class="flex items-center gap-2"><span class="h-2 w-2 rounded-full bg-red-500"></span>Failed</span>
-						<span class="text-xs tabular-nums {statusCounts.failed > 0 ? 'font-semibold text-red-600 dark:text-red-400' : 'text-gray-300 dark:text-gray-600'}">{statusCounts.failed}</span>
-					</button>
-					<button onclick={() => (statusFilter = 'succeeded')} class={sidebarItemClass(statusFilter === 'succeeded')}>
-						<span class="flex items-center gap-2"><span class="h-2 w-2 rounded-full bg-green-500"></span>Succeeded</span>
-						<span class="text-xs tabular-nums text-gray-400 dark:text-gray-500">{statusCounts.succeeded}</span>
-					</button>
-					<button onclick={() => (statusFilter = 'idle')} class={sidebarItemClass(statusFilter === 'idle')}>
-						<span class="flex items-center gap-2"><span class="h-2 w-2 rounded-full bg-gray-300 dark:bg-gray-600"></span>Idle</span>
-						<span class="text-xs tabular-nums text-gray-400 dark:text-gray-500">{statusCounts.idle}</span>
-					</button>
-				</SidebarGroup>
-
-				<!-- Namespace filter group -->
-				{#if uniqueNamespaces.length > 1}
-					<SidebarGroup border>
-						<p class="mb-1 px-3 text-[11px] font-semibold uppercase tracking-widest text-gray-400 dark:text-gray-500">Namespace</p>
-						<button onclick={() => (namespaceFilter = 'all')} class={sidebarItemClass(namespaceFilter === 'all')}>All</button>
-						{#each uniqueNamespaces as ns}
-							<button onclick={() => (namespaceFilter = ns)} class={sidebarItemClass(namespaceFilter === ns)}>
-								<span class="truncate">{ns}</span>
-							</button>
-						{/each}
-					</SidebarGroup>
-				{/if}
-
+	<!-- ── Toolbar: search + Filter button + active chips + group-by ── -->
+	<header class="sticky top-0 z-20 border-b border-gray-200 bg-white/95 backdrop-blur dark:border-gray-700 dark:bg-gray-800/95">
+		<div class="flex flex-wrap items-center gap-x-2 gap-y-1.5 px-4 py-2 sm:px-6">
+			<!-- Search -->
+			<div class="relative w-full min-w-0 sm:w-56">
+				<SearchOutline class="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-gray-400" />
+				<input
+					type="search"
+					placeholder="Search rollouts…"
+					bind:value={searchQuery}
+					class="h-8 w-full rounded-md border border-gray-200 bg-gray-50 pl-8 pr-2 text-[13px] text-gray-900 placeholder-gray-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-700/40 dark:text-white dark:placeholder-gray-500"
+				/>
 			</div>
-		</Sidebar>
-	</div>
 
-	<!-- ── Right side: mobile filter bar + cards ── -->
-	<div class="flex min-w-0 flex-1 flex-col overflow-hidden">
+			<!-- Filter trigger -->
+			<button
+				type="button"
+				onclick={() => (showFilters = !showFilters)}
+				aria-expanded={showFilters}
+				aria-controls="filter-panel"
+				class="inline-flex h-8 cursor-pointer items-center gap-1.5 rounded-md border px-2.5 text-[13px] font-medium transition-colors
+					{showFilters
+						? 'border-blue-300 bg-blue-50 text-blue-700 dark:border-blue-800/60 dark:bg-blue-900/30 dark:text-blue-300'
+						: activeFilterCount > 0
+							? 'border-gray-300 bg-gray-50 text-gray-800 hover:bg-gray-100 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600'
+							: 'border-gray-200 bg-white text-gray-600 hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700/60'}"
+			>
+				{#if activeFilterCount > 0}
+					<FilterSolid class="h-3.5 w-3.5" />
+				{:else}
+					<FilterOutline class="h-3.5 w-3.5" />
+				{/if}
+				Filters
+				{#if activeFilterCount > 0}
+					<span class="inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-blue-600 px-1 text-[10px] font-semibold tabular-nums text-white dark:bg-blue-500">{activeFilterCount}</span>
+				{/if}
+				{#if showFilters}
+					<ChevronUpOutline class="h-3 w-3 opacity-60" />
+				{:else}
+					<ChevronDownOutline class="h-3 w-3 opacity-60" />
+				{/if}
+			</button>
 
-		<!-- Mobile filter bar (hidden on desktop) -->
-		<div class="sticky top-0 z-10 border-b border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900 lg:hidden">
-			<div class="flex flex-col gap-2 px-3 py-2.5">
-				<!-- Search -->
-				<div class="relative">
-					<SearchOutline class="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-gray-400" />
-					<input
-						type="search"
-						placeholder="Search rollouts…"
-						bind:value={searchQuery}
-						class="w-full rounded-md border border-gray-200 bg-gray-50 py-1.5 pl-8 pr-2 text-sm text-gray-900 placeholder-gray-400 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white"
-					/>
+			<!-- Group-by toggle (always stays at the right of row 1) -->
+			<div class="ml-auto inline-flex items-center gap-1.5 text-[11px] text-gray-500 dark:text-gray-400">
+				<span class="hidden sm:inline">Group</span>
+				<div class="inline-flex h-8 items-center rounded-md border border-gray-200 bg-white p-0.5 dark:border-gray-700 dark:bg-gray-800">
+					{#each GROUP_OPTIONS as opt}
+						{@const sel = groupBy === opt.value}
+						<button
+							type="button"
+							onclick={() => (groupBy = opt.value)}
+							aria-pressed={sel}
+							class="cursor-pointer rounded px-2.5 py-1 text-[11px] font-medium transition-colors
+								{sel
+									? 'bg-gray-900 text-white dark:bg-gray-200 dark:text-gray-900'
+									: 'text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-200'}"
+						>{opt.label}</button>
+					{/each}
 				</div>
-				<!-- Selects row -->
-				<div class="flex gap-2">
-					<select
-						bind:value={statusFilter}
-						class="min-w-0 flex-1 rounded-md border border-gray-200 bg-gray-50 py-1.5 px-2 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300"
+			</div>
+		</div>
+
+		<!-- Row 2: active filter chips (own row so they never push the group toggle) -->
+		{#if !showFilters && activeFilterCount > 0}
+			<div class="flex flex-wrap items-center gap-1 px-4 pb-2 sm:px-6">
+				{#each statusFilters as k}
+					{@const meta = STATUS_META[k]}
+					<button
+						type="button"
+						onclick={() => toggleStatus(k)}
+						title="Remove filter"
+						class="inline-flex h-5 cursor-pointer items-center gap-1 rounded-full border px-1.5 text-[10px] font-medium transition-colors
+							{meta.color === 'red'    ? 'border-red-300 bg-red-100 text-red-800 hover:bg-red-200/70 dark:border-red-800/60 dark:bg-red-900/40 dark:text-red-200'
+							: meta.color === 'yellow' ? 'border-yellow-300 bg-yellow-100 text-yellow-800 hover:bg-yellow-200/70 dark:border-yellow-800/60 dark:bg-yellow-900/40 dark:text-yellow-200'
+							: meta.color === 'green'  ? 'border-green-300 bg-green-100 text-green-800 hover:bg-green-200/70 dark:border-green-800/60 dark:bg-green-900/40 dark:text-green-200'
+							: meta.color === 'orange' ? 'border-orange-300 bg-orange-100 text-orange-800 hover:bg-orange-200/70 dark:border-orange-800/60 dark:bg-orange-900/40 dark:text-orange-200'
+							:                           'border-gray-300 bg-gray-100 text-gray-800 hover:bg-gray-200/70 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100'}"
 					>
-						<option value="all">All statuses</option>
-						<option value="active">Active ({statusCounts.active})</option>
-						<option value="failed">Failed ({statusCounts.failed})</option>
-						<option value="succeeded">Succeeded ({statusCounts.succeeded})</option>
-						<option value="idle">Idle ({statusCounts.idle})</option>
-					</select>
-					{#if uniqueNamespaces.length > 1}
-						<select
-							bind:value={namespaceFilter}
-							class="min-w-0 flex-1 rounded-md border border-gray-200 bg-gray-50 py-1.5 px-2 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300"
-						>
-							<option value="all">All namespaces</option>
-							{#each uniqueNamespaces as ns}
-								<option value={ns}>{ns}</option>
+						<span class="h-1.5 w-1.5 rounded-full {meta.dot}"></span>
+						{meta.label}
+						<CloseOutline class="h-2.5 w-2.5 opacity-70" />
+					</button>
+				{/each}
+				{#each envFilters as env}
+					<button
+						type="button"
+						onclick={() => toggleEnv(env)}
+						title="Remove filter"
+						class="inline-flex h-5 cursor-pointer items-center gap-1 rounded-full border border-blue-300 bg-blue-100 px-1.5 text-[10px] font-semibold uppercase tracking-wider text-blue-800 transition-colors hover:bg-blue-200/70 dark:border-blue-800/60 dark:bg-blue-900/40 dark:text-blue-200"
+					>{env}<CloseOutline class="h-2.5 w-2.5 opacity-70" /></button>
+				{/each}
+				{#each nsFilters as ns}
+					<button
+						type="button"
+						onclick={() => toggleNs(ns)}
+						title="Remove filter"
+						class="inline-flex h-5 cursor-pointer items-center gap-1 rounded-full border border-gray-300 bg-gray-100 px-1.5 font-mono text-[10px] font-medium text-gray-800 transition-colors hover:bg-gray-200/70 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+					>{ns}<CloseOutline class="h-2.5 w-2.5 opacity-70" /></button>
+				{/each}
+			</div>
+		{/if}
+
+		<!-- Expandable filter panel -->
+		{#if showFilters}
+			<div id="filter-panel" transition:slide={{ duration: 150 }} class="border-t border-gray-100 bg-gray-50/50 dark:border-gray-700/60 dark:bg-gray-900/30">
+				<div class="grid gap-x-6 gap-y-4 px-4 py-4 sm:grid-cols-2 sm:px-6 lg:grid-cols-3">
+					<!-- Status section -->
+					<section>
+						<div class="mb-2 flex items-baseline justify-between">
+							<h3 class="text-[10px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">Status</h3>
+							{#if statusFilters.length > 0}
+								<button type="button" onclick={() => (statusFilters = [])} class="text-[10px] text-gray-400 hover:text-gray-700 dark:hover:text-gray-200">Clear</button>
+							{/if}
+						</div>
+						<div class="flex flex-col gap-1">
+							{#each STATUS_FILTER_KEYS as k}
+								{@const meta = STATUS_META[k]}
+								{@const c = k === 'failed' ? statusCounts.failed : k === 'active' ? statusCounts.active : k === 'stuck' ? statusCounts.stuck : k === 'succeeded' ? statusCounts.succeeded : statusCounts.idle}
+								{@const sel = statusFilters.includes(k)}
+								{@const empty = c === 0 && !sel}
+								<button
+									type="button"
+									onclick={() => toggleStatus(k)}
+									aria-pressed={sel}
+									title={meta.help}
+									disabled={empty}
+									class="group flex items-center gap-2 rounded-md px-2 py-1 text-left text-[13px] transition-colors disabled:cursor-not-allowed disabled:opacity-40
+										{sel
+											? 'bg-white shadow-sm ring-1 ring-gray-200 dark:bg-gray-800 dark:ring-gray-700'
+											: 'hover:bg-white dark:hover:bg-gray-800/60'}"
+								>
+									<span class="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded border-2 {sel ? 'border-blue-600 bg-blue-600 dark:border-blue-500 dark:bg-blue-500' : 'border-gray-300 bg-white dark:border-gray-600 dark:bg-gray-800'}">
+										{#if sel}<CheckCircleSolid class="h-3 w-3 text-white" />{/if}
+									</span>
+									<span class="h-1.5 w-1.5 shrink-0 rounded-full {meta.dot}"></span>
+									<span class="flex-1 truncate text-gray-700 dark:text-gray-300">{meta.label}</span>
+									<span class="shrink-0 tabular-nums text-[11px] text-gray-400 dark:text-gray-500">{c}</span>
+								</button>
 							{/each}
-						</select>
+						</div>
+					</section>
+
+					<!-- Environment section -->
+					{#if uniqueEnvironments.length > 0}
+						<section>
+							<div class="mb-2 flex items-baseline justify-between">
+								<h3 class="text-[10px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">Environment</h3>
+								{#if envFilters.length > 0}
+									<button type="button" onclick={() => (envFilters = [])} class="text-[10px] text-gray-400 hover:text-gray-700 dark:hover:text-gray-200">Clear</button>
+								{/if}
+							</div>
+							<div class="flex flex-col gap-1">
+								{#each uniqueEnvironments as env}
+									{@const sel = envFilters.includes(env)}
+									{@const c = envCount(env)}
+									<button
+										type="button"
+										onclick={() => toggleEnv(env)}
+										aria-pressed={sel}
+										class="group flex items-center gap-2 rounded-md px-2 py-1 text-left text-[13px] transition-colors
+											{sel
+												? 'bg-white shadow-sm ring-1 ring-gray-200 dark:bg-gray-800 dark:ring-gray-700'
+												: 'hover:bg-white dark:hover:bg-gray-800/60'}"
+									>
+										<span class="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded border-2 {sel ? 'border-blue-600 bg-blue-600 dark:border-blue-500 dark:bg-blue-500' : 'border-gray-300 bg-white dark:border-gray-600 dark:bg-gray-800'}">
+											{#if sel}<CheckCircleSolid class="h-3 w-3 text-white" />{/if}
+										</span>
+										<span class="flex-1 truncate font-mono text-[12px] uppercase tracking-wider text-gray-700 dark:text-gray-300">{env}</span>
+										<span class="shrink-0 tabular-nums text-[11px] text-gray-400 dark:text-gray-500">{c}</span>
+									</button>
+								{/each}
+							</div>
+						</section>
+					{/if}
+
+					<!-- Namespace section -->
+					{#if uniqueNamespaces.length > 1}
+						<section>
+							<div class="mb-2 flex items-baseline justify-between">
+								<h3 class="text-[10px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">Namespace</h3>
+								{#if nsFilters.length > 0}
+									<button type="button" onclick={() => (nsFilters = [])} class="text-[10px] text-gray-400 hover:text-gray-700 dark:hover:text-gray-200">Clear</button>
+								{/if}
+							</div>
+							<div class="flex max-h-48 flex-col gap-1 overflow-y-auto">
+								{#each uniqueNamespaces as ns}
+									{@const sel = nsFilters.includes(ns)}
+									{@const c = nsCount(ns)}
+									<button
+										type="button"
+										onclick={() => toggleNs(ns)}
+										aria-pressed={sel}
+										class="group flex items-center gap-2 rounded-md px-2 py-1 text-left text-[13px] transition-colors
+											{sel
+												? 'bg-white shadow-sm ring-1 ring-gray-200 dark:bg-gray-800 dark:ring-gray-700'
+												: 'hover:bg-white dark:hover:bg-gray-800/60'}"
+									>
+										<span class="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded border-2 {sel ? 'border-blue-600 bg-blue-600 dark:border-blue-500 dark:bg-blue-500' : 'border-gray-300 bg-white dark:border-gray-600 dark:bg-gray-800'}">
+											{#if sel}<CheckCircleSolid class="h-3 w-3 text-white" />{/if}
+										</span>
+										<span class="flex-1 truncate font-mono text-[12px] text-gray-700 dark:text-gray-300">{ns}</span>
+										<span class="shrink-0 tabular-nums text-[11px] text-gray-400 dark:text-gray-500">{c}</span>
+									</button>
+								{/each}
+							</div>
+						</section>
 					{/if}
 				</div>
 			</div>
-		</div>
+		{/if}
+	</header>
 
-		<!-- Cards area -->
-		<div class="flex-1 overflow-y-auto dark:bg-gray-900">
-			{#if loading}
-				<div class="grid grid-cols-1 gap-2.5 p-4 sm:grid-cols-2 xl:grid-cols-3">
-					{#each Array(6) as _}
-						<div class="rounded-lg border border-gray-200 p-3 dark:border-gray-700">
-							<div class="flex items-center gap-2.5">
-								<div class="h-3 w-3 shrink-0 animate-pulse rounded-full bg-gray-200 dark:bg-gray-700"></div>
-								<div class="h-3 flex-1 animate-pulse rounded bg-gray-200 dark:bg-gray-700"></div>
-								<div class="h-3 w-8 animate-pulse rounded bg-gray-200 dark:bg-gray-700"></div>
-							</div>
-							<div class="mt-2 flex gap-2 pl-5">
-								<div class="h-2.5 w-16 animate-pulse rounded bg-gray-200 dark:bg-gray-700"></div>
-							</div>
+	<!-- ── Group cards grid ── -->
+	<div class="flex-1 px-4 py-4 sm:px-6">
+		{#if loading}
+			<div class="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+				{#each Array(6) as _}
+					<div class="rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+						<div class="border-b border-gray-100 px-4 py-2.5 dark:border-gray-700/60">
+							<div class="h-4 w-32 animate-pulse rounded bg-gray-200 dark:bg-gray-700"></div>
 						</div>
-					{/each}
-				</div>
-			{:else if error}
-				<div class="p-4"><Alert color="red">{error}</Alert></div>
-			{:else if rollouts.length === 0}
-				<div class="p-4"><Alert color="yellow">No rollouts found</Alert></div>
-			{:else if totalFiltered === 0}
-				<div class="py-16 text-center">
-					<p class="text-sm text-gray-500 dark:text-gray-400">No results.</p>
-					<button
-						onclick={() => { searchQuery = ''; namespaceFilter = 'all'; statusFilter = 'all'; }}
-						class="mt-2 text-xs text-blue-600 hover:underline dark:text-blue-400"
-					>Clear filters</button>
-				</div>
-			{:else}
-				<div class="flex flex-col gap-4 p-3 sm:p-4">
-					{#each filteredRolloutsByNamespace as group}
-						<div>
-							{#if filteredRolloutsByNamespace.length > 1}
-								<div class="mb-2 flex items-center gap-2.5">
-									<span class="shrink-0 text-[11px] font-semibold uppercase tracking-widest text-gray-400 dark:text-gray-500">{group.ns}</span>
-									<div class="h-px flex-1 bg-gray-200 dark:bg-gray-700"></div>
+						<div class="space-y-3 p-4">
+							{#each Array(2) as _}
+								<div>
+									<div class="h-3.5 w-3/4 animate-pulse rounded bg-gray-200 dark:bg-gray-700"></div>
+									<div class="mt-1.5 h-2.5 w-1/2 animate-pulse rounded bg-gray-100 dark:bg-gray-700"></div>
 								</div>
-							{/if}
+							{/each}
+						</div>
+					</div>
+				{/each}
+			</div>
+		{:else if error}
+			<Alert color="red">{error}</Alert>
+		{:else if rollouts.length === 0}
+			<Alert color="yellow">No rollouts found</Alert>
+		{:else if totalFiltered === 0}
+			<div class="py-20 text-center">
+				<p class="text-sm text-gray-500 dark:text-gray-400">No rollouts match these filters.</p>
+				<button onclick={() => { searchQuery = ''; statusFilters = []; envFilters = []; nsFilters = []; }} class="mt-3 inline-flex items-center gap-1 rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600">Clear filters</button>
+			</div>
+		{:else}
+			<div class="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+				{#each groupedRows as group}
+					{@const drift = groupBy === 'name' && group.versions.size > 1}
+					{@const groupHighlighted =
+						(group.labelKind === 'namespace' && nsFilters.includes(group.key)) ||
+						(group.labelKind === 'environment' && envFilters.includes(group.key))}
+					<section class="overflow-hidden rounded-lg border bg-white shadow-sm transition-all hover:shadow-md dark:bg-gray-800
+						{groupHighlighted ? 'border-blue-400 dark:border-blue-500' : 'border-gray-200 dark:border-gray-700'}"
+					>
+						<!-- Group header -->
+						<button
+							type="button"
+							onclick={() => toggleGroupKey(group)}
+							aria-pressed={groupHighlighted}
+							class="flex w-full items-center justify-between gap-2 border-b px-4 py-2.5 text-left transition-colors
+								{groupHighlighted
+									? 'border-blue-200 bg-blue-50 hover:bg-blue-100/70 dark:border-blue-800/40 dark:bg-blue-900/20 dark:hover:bg-blue-900/30'
+									: group.severity === 3
+										? 'border-red-100 bg-red-50/60 hover:bg-red-50 dark:border-red-900/40 dark:bg-red-900/10 dark:hover:bg-red-900/20'
+										: group.severity === 2
+											? 'border-orange-100 bg-orange-50/60 hover:bg-orange-50 dark:border-orange-900/40 dark:bg-orange-900/10 dark:hover:bg-orange-900/20'
+											: group.severity === 1
+												? 'border-yellow-100 bg-yellow-50/60 hover:bg-yellow-50 dark:border-yellow-900/40 dark:bg-yellow-900/10 dark:hover:bg-yellow-900/20'
+												: 'border-gray-100 bg-gray-50/60 hover:bg-gray-100 dark:border-gray-700/60 dark:bg-gray-800/60 dark:hover:bg-gray-700/40'}"
+						>
+							<div class="flex min-w-0 items-baseline gap-2">
+								{#if group.labelKind === 'environment'}
+									<Badge color="dark" border rounded class="environment-theme-badge"
+										style={(group.rows[0]?.theme) ? getEnvironmentThemeStyle(group.rows[0].theme) : undefined}
+									>{group.label}</Badge>
+								{:else}
+									<h3 class="truncate text-xs font-semibold
+										{group.labelKind === 'name' ? 'text-gray-900 dark:text-white' : 'font-mono text-gray-700 dark:text-gray-200'}
+										{groupHighlighted ? 'text-blue-700 dark:text-blue-300' : ''}"
+									>{group.label}</h3>
+								{/if}
+								<span class="shrink-0 text-[11px] tabular-nums text-gray-400 dark:text-gray-500">{group.rows.length}</span>
+								{#if drift}
+									<Badge color="orange" rounded class="text-[10px]" title="Versions differ across deployments">drift</Badge>
+								{/if}
+							</div>
+							<div class="flex shrink-0 items-center gap-1.5">
+								<!-- Status badges -->
+								{#if group.failedCount > 0}
+									<Badge color="red" rounded class="text-[10px]">{group.failedCount} failed</Badge>
+								{:else if group.stuckCount > 0}
+									<Badge color="orange" rounded class="text-[10px]">{group.stuckCount} stuck</Badge>
+								{:else if group.activeCount > 0}
+									<Badge color="yellow" rounded class="text-[10px]">{group.activeCount} active</Badge>
+								{:else}
+									<CheckCircleSolid class="h-3.5 w-3.5 text-green-500 dark:text-green-400" />
+								{/if}
+								{#if groupHighlighted}
+									<CloseOutline class="h-3.5 w-3.5 text-blue-500" />
+								{/if}
+							</div>
+						</button>
 
-							<div class="grid grid-cols-1 gap-2 sm:grid-cols-2 xl:grid-cols-3">
-								{#each group.rollouts as r}
-									{@const ns            = r.metadata?.namespace || 'default'}
-									{@const name          = r.metadata?.name || ''}
-									{@const latest        = r.status?.history?.[0]}
-									{@const status        = getBakeStatus(r)}
-									{@const versionLabel  = latest?.version ? getDisplayVersion(latest.version) : null}
-									{@const upgradeCount  = r.status?.releaseCandidates?.length || 0}
-									{@const failedHCCount = latest?.failedHealthChecks?.length || 0}
-									{@const activeLabel   = ACTIVE_LABEL[status] ?? null}
-									{@const statusText    = STATUS_TEXT[status] ?? STATUS_TEXT['None']}
-									{@const rolloutTheme  = getRolloutEnvironmentTheme(r)}
-									{@const bakeProgressPct = (() => {
-										if (status !== 'InProgress' || !latest?.bakeStartTime || !r.spec?.bakeTime) return null;
-										const elapsed = $now.getTime() - new Date(latest.bakeStartTime).getTime();
-										const total = parseDuration(r.spec.bakeTime);
-										return total > 0 ? Math.min(100, Math.max(0, (elapsed / total) * 100)) : null;
-									})()}
+						<!-- Group time-axis labels (oldest → now) -->
+						{#if group.rangeSpan > 60000}
+							<div class="flex justify-between border-b border-gray-100 px-4 pt-1 pb-0.5 font-mono text-[9px] uppercase tracking-wider text-gray-400 dark:border-gray-700/60 dark:text-gray-500">
+								<span>{compactSeconds(Math.floor(($now.getTime() - group.rangeMin) / 1000))} ago</span>
+								<span>now</span>
+							</div>
+						{/if}
 
+						<!-- Rows -->
+						<ul class="divide-y divide-gray-100 dark:divide-gray-700/60">
+							{#each group.rows as row}
+								{@const badge = STATUS_BADGE[row.status] ?? STATUS_BADGE['None']}
+								{@const rowTint = row.status === 'Failed'
+									? 'bg-red-50/40 dark:bg-red-900/10 hover:bg-red-50/70 dark:hover:bg-red-900/20'
+									: isRunning(row.status)
+										? 'bg-yellow-50/30 dark:bg-yellow-900/5 hover:bg-yellow-50/60 dark:hover:bg-yellow-900/10'
+										: 'hover:bg-gray-50 dark:hover:bg-gray-700/40'}
+								<li>
 									<a
-										href="/rollouts/{ns}/{name}"
-										style={rolloutTheme ? getEnvironmentThemeStyle(rolloutTheme) : undefined}
-										class="environment-theme-scope group flex flex-col overflow-hidden rounded-lg border transition-colors
-											{status === 'Failed'
-												? 'border-red-200 bg-red-50 hover:border-red-300 dark:border-red-900/50 dark:bg-red-950/20 dark:hover:border-red-800'
-												: 'border-gray-200 bg-white hover:border-gray-300 dark:border-gray-700 dark:bg-gray-800 dark:hover:border-gray-600'}"
+										href="/rollouts/{row.ns}/{row.name}"
+										style={row.theme ? getEnvironmentThemeStyle(row.theme) : undefined}
+										class="environment-theme-scope relative block px-4 py-2.5 transition-colors {rowTint}"
 									>
-										<div class="flex items-center gap-2 px-3 pt-2.5 pb-1.5">
-											<BakeStatusIcon bakeStatus={status} size="small" class="shrink-0" />
-											<span class="min-w-0 flex-1 truncate text-sm font-medium text-gray-900 dark:text-white">{name}</span>
-											{#if rolloutTheme}
-												<Badge
-													color="gray"
-													size="small"
-													class="environment-theme-badge shrink-0 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider"
+										<!-- Line 1: dot + identity + secondary tags -->
+										<div class="flex items-center gap-2">
+											<span class="relative flex h-2 w-2 shrink-0">
+												{#if isRunning(row.status)}
+													<span class="absolute inline-flex h-full w-full animate-ping rounded-full opacity-60 {badge.dot}"></span>
+												{/if}
+												<span class="relative inline-flex h-2 w-2 rounded-full {badge.dot}"></span>
+											</span>
+											<!-- Primary identity (changes by grouping mode) -->
+											{#if groupBy === 'name'}
+												<h4 class="min-w-0 flex-1 truncate font-mono text-[12px] text-gray-700 dark:text-gray-300">{row.ns}</h4>
+												{#if row.theme}
+													<Badge color="dark" border rounded class="environment-theme-badge shrink-0">{row.theme.label}</Badge>
+												{/if}
+											{:else if groupBy === 'environment'}
+												<h4 class="min-w-0 flex-1 truncate text-sm font-semibold text-gray-900 dark:text-white">{row.name}</h4>
+												<span class="shrink-0 truncate font-mono text-[11px] text-gray-500 dark:text-gray-500">{row.ns}</span>
+											{:else}
+												<h4 class="min-w-0 flex-1 truncate text-sm font-semibold text-gray-900 dark:text-white">{row.name}</h4>
+												{#if row.theme}
+													<Badge color="dark" border rounded class="environment-theme-badge shrink-0">{row.theme.label}</Badge>
+												{/if}
+											{/if}
+										</div>
+
+										<!-- Line 2: status · version · signals · age -->
+										<div class="mt-1 flex flex-wrap items-center gap-x-1.5 gap-y-0.5 pl-4 text-[11px] text-gray-500 dark:text-gray-400">
+											<span class="shrink-0 {row.status === 'Failed' ? 'font-medium text-red-600 dark:text-red-400' : isRunning(row.status) ? 'font-medium text-yellow-700 dark:text-yellow-400' : ''}">
+												{badge.label}{#if row.bakeProgressPct !== null}&nbsp;{Math.round(row.bakeProgressPct)}%{/if}
+											</span>
+											{#if row.version}
+												<span class="text-gray-300 dark:text-gray-600">·</span>
+												<span class="min-w-0 truncate font-mono">{row.version}</span>
+											{/if}
+											{#if row.pinnedVersion}
+												<span class="text-gray-300 dark:text-gray-600">·</span>
+												<span
+													class="inline-flex shrink-0 items-center gap-0.5 font-medium text-orange-600 dark:text-orange-400"
+													title="Pinned to {row.pinnedVersion} — automated deploys are paused until the pin is cleared"
 												>
-													{rolloutTheme.label}
-												</Badge>
-											{/if}
-											{#if latest?.timestamp}
-												<span class="shrink-0 text-xs tabular-nums text-gray-400 dark:text-gray-500">{compactTime(latest.timestamp, $now)}</span>
-											{/if}
-										</div>
-										<div class="flex min-h-[1.75rem] items-center gap-1.5 px-3 pb-2.5 pl-7">
-											{#if versionLabel}
-												<span class="font-mono text-xs text-gray-400 dark:text-gray-500">{versionLabel}</span>
-											{/if}
-											{#if activeLabel}
-												<span class="text-xs font-medium {statusText}">{activeLabel}</span>
-											{/if}
-											<div class="flex-1"></div>
-											{#if upgradeCount > 0}
-												<span class="inline-flex shrink-0 items-center gap-0.5 rounded-full bg-orange-100 px-1.5 py-0.5 text-xs font-semibold text-orange-700 dark:bg-orange-900/30 dark:text-orange-400">
-													<ArrowUpOutline class="h-2.5 w-2.5" />{upgradeCount}
+													<PauseSolid class="h-3 w-3" />pinned
 												</span>
 											{/if}
-											{#if failedHCCount > 0}
-												<span class="inline-flex shrink-0 items-center gap-0.5 rounded-full bg-red-100 px-1.5 py-0.5 text-xs font-semibold text-red-700 dark:bg-red-900/30 dark:text-red-400">
-													<HeartSolid class="h-2.5 w-2.5" />{failedHCCount}
+											{#if row.isStuck || row.waitingCandidateVersion}
+												{@const waitId = `wait-${row.ns}-${row.name}`.replace(/[^a-z0-9-]/gi, '-')}
+												<span class="text-gray-300 dark:text-gray-600">·</span>
+												<span
+													id={waitId}
+													class="inline-flex shrink-0 cursor-help items-center gap-0.5
+														{row.isStuck ? 'font-medium text-orange-600 dark:text-orange-400' : 'text-gray-500 dark:text-gray-400'}"
+												>
+													<ClockSolid class="h-3 w-3" />
+													{row.isStuck ? 'stuck' : 'waiting'} {compactSeconds(row.waitingSeconds)}
+													<QuestionCircleOutline class="ml-0.5 h-3 w-3 opacity-60" />
+												</span>
+											{:else if row.upgradeCount > 0}
+												<span class="text-gray-300 dark:text-gray-600">·</span>
+												<span class="inline-flex shrink-0 items-center gap-0.5 tabular-nums text-gray-500 dark:text-gray-400" title="{row.upgradeCount} pending upgrades">
+													<ArrowUpOutline class="h-3 w-3" />{row.upgradeCount}
 												</span>
 											{/if}
+											{#if row.failedHCCount > 0}
+												<span class="text-gray-300 dark:text-gray-600">·</span>
+												<span class="inline-flex shrink-0 items-center gap-0.5 tabular-nums text-red-600 dark:text-red-400" title="{row.failedHCCount} failed health checks">
+													<HeartSolid class="h-3 w-3" />{row.failedHCCount}
+												</span>
+											{/if}
+											{#if row.age}
+												<span class="text-gray-300 dark:text-gray-600">·</span>
+												<span class="shrink-0 font-mono tabular-nums">{row.age}</span>
+											{/if}
 										</div>
-										{#if bakeProgressPct !== null}
-											<div class="h-0.5 w-full bg-gray-100 dark:bg-gray-700">
-												<div class="h-full bg-yellow-400 transition-all duration-300 dark:bg-yellow-500" style="width: {bakeProgressPct}%"></div>
+
+										<!-- Per-rollout timeline aligned within the group's time range — for spotting cross-deployment correlations -->
+										{#if row.displayHistory.length > 0}
+											<div class="mt-2 pl-4">
+												<div class="relative h-2.5">
+													<!-- track -->
+													<div class="absolute inset-x-0 top-1 h-0.5 rounded-full bg-gray-200 dark:bg-gray-700/60"></div>
+													<!-- now marker -->
+													<span class="absolute top-0 h-2.5 w-px bg-gray-400 dark:bg-gray-500" style="right: 0; left: auto;"></span>
+													<!-- deploy markers -->
+													{#each row.displayHistory as h}
+														{@const t = new Date(h.ts).getTime()}
+														{@const x = Math.min(100, Math.max(0, ((t - group.rangeMin) / group.rangeSpan) * 100))}
+														{@const b = STATUS_BADGE[h.status] ?? STATUS_BADGE['None']}
+														<span
+															class="absolute top-0 h-2.5 w-2.5 -translate-x-1/2 rounded-full ring-2 {b.sparkBg} {row.status === 'Failed' ? 'ring-red-50/40 dark:ring-red-900/10' : isRunning(row.status) ? 'ring-yellow-50/30 dark:ring-yellow-900/5' : 'ring-white dark:ring-gray-800'}"
+															style="left: {x}%"
+															title="{h.version} · {h.status}"
+														></span>
+													{/each}
+												</div>
 											</div>
 										{/if}
+
+										{#if row.bakeProgressPct !== null}
+											<span class="pointer-events-none absolute inset-x-0 bottom-0 h-0.5 bg-gray-100 dark:bg-gray-700">
+												<span class="block h-full bg-yellow-400 transition-all duration-500 dark:bg-yellow-500" style="width: {row.bakeProgressPct}%"></span>
+											</span>
+										{/if}
 									</a>
-								{/each}
-							</div>
-						</div>
-					{/each}
-				</div>
-			{/if}
-		</div>
+
+									{#if row.isStuck || row.waitingCandidateVersion}
+										{@const waitId = `wait-${row.ns}-${row.name}`.replace(/[^a-z0-9-]/gi, '-')}
+										<Popover triggeredBy={`#${waitId}`} class="max-w-sm">
+											<div class="p-3">
+												<div class="mb-2 flex items-center gap-2">
+													<ClockSolid class="h-4 w-4 {row.isStuck ? 'text-orange-500' : 'text-gray-400'}" />
+													<h4 class="text-sm font-semibold text-gray-900 dark:text-white">
+														{row.isStuck ? 'Stuck on gates' : 'Waiting on gates'}
+													</h4>
+												</div>
+												<dl class="space-y-1 text-xs text-gray-600 dark:text-gray-300">
+													<div class="flex justify-between gap-3">
+														<dt class="text-gray-500 dark:text-gray-400">Candidate</dt>
+														<dd class="truncate font-mono">{row.waitingCandidateVersion}</dd>
+													</div>
+													<div class="flex justify-between gap-3">
+														<dt class="text-gray-500 dark:text-gray-400">Waiting</dt>
+														<dd class="font-mono tabular-nums {row.isStuck ? 'font-semibold text-orange-600 dark:text-orange-400' : ''}">{compactSeconds(row.waitingSeconds)}</dd>
+													</div>
+													<div class="flex justify-between gap-3">
+														<dt class="text-gray-500 dark:text-gray-400">Threshold</dt>
+														<dd class="font-mono tabular-nums">{compactSeconds(row.stuckThresholdSec)}</dd>
+													</div>
+													<div class="flex justify-between gap-3">
+														<dt class="text-gray-500 dark:text-gray-400">Gates blocking</dt>
+														<dd class="tabular-nums">{row.gatesBlocking}</dd>
+													</div>
+												</dl>
+												<p class="mt-2 border-t border-gray-100 pt-2 text-[11px] leading-relaxed text-gray-500 dark:border-gray-700 dark:text-gray-400">
+													Threshold = mean + 1·stdev of historical wait times (from <span class="font-mono">version.created</span> to deploy). With &lt;3 samples, falls back to 2× max historical wait, then to 7 days.
+												</p>
+											</div>
+										</Popover>
+									{/if}
+								</li>
+							{/each}
+						</ul>
+					</section>
+				{/each}
+			</div>
+		{/if}
 	</div>
 
 </div>

--- a/frontend/src/lib/api/rollouts.ts
+++ b/frontend/src/lib/api/rollouts.ts
@@ -21,6 +21,7 @@ export type RolloutResponse = {
 
 export type RolloutsListResponse = {
     rollouts: { items: Rollout[] };
+    environments?: { items: Environment[] };
 };
 
 type QueryOverrides<TData> = Omit<

--- a/frontend/src/lib/environment-theme.ts
+++ b/frontend/src/lib/environment-theme.ts
@@ -16,6 +16,13 @@ export type EnvironmentTheme = ThemePreset & {
 	surfaceColor: string;
 	darkSurfaceColor: string;
 	darkTextColor: string;
+	/**
+	 * The raw environment name (e.g. "staging", "dev", "kuberik-demo").
+	 * Pages other than the Navbar should display this as the environment value
+	 * (typically inside a JoinedBadge labelled "Environment"), reserving the
+	 * canonical preset `label` ("Staging", "Development") for the Navbar only.
+	 */
+	environmentName: string;
 };
 
 const PRESET_THEMES: Record<string, ThemePreset> = {
@@ -105,14 +112,18 @@ function resolveThemeLabel({
 	if (themeValue && preset) return preset.label;
 	if (themeValue && inlineThemeColor) return environmentName || 'Custom';
 	if (themeName === 'custom') return environmentName || 'Custom';
-	return environmentName || preset?.label || labelFromThemeName(themeName);
+	// Prefer the preset's canonical label (e.g. "Staging") over the raw
+	// environmentName ("staging") so labels are consistent regardless of
+	// whether the theme came from a rollout annotation or an Environment.
+	return preset?.label || environmentName || labelFromThemeName(themeName);
 }
 
-function buildEnvironmentTheme(name: string, label: string, color: string): EnvironmentTheme {
+function buildEnvironmentTheme(name: string, label: string, environmentName: string, color: string): EnvironmentTheme {
 	const normalizedColor = normalizeHexColor(color) ?? '#2563eb';
 	return {
 		name,
 		label,
+		environmentName,
 		color: normalizedColor,
 		textColor: mixWith(normalizedColor, '#000000', 0.18),
 		borderColor: mixWith(normalizedColor, '#ffffff', 0.64),
@@ -151,8 +162,16 @@ export function getRolloutEnvironmentTheme(
 		themeName,
 		themeValue
 	});
+	// Raw environment name for display in pages other than the Navbar.
+	// Only sources we treat as a *real* environment value: Environment.spec.environment,
+	// or an explicit theme-label annotation. We do NOT fall back to the preset
+	// label here, because a rollout with no Environment shouldn't be shown as
+	// having one — match the detail page, which only renders the env badge when
+	// environment.spec.environment is present.
+	const rawEnvironmentName =
+		environmentName || annotations?.[ENVIRONMENT_THEME_LABEL_ANNOTATION]?.trim() || '';
 
-	return buildEnvironmentTheme(themeName, label, color);
+	return buildEnvironmentTheme(themeName, label, rawEnvironmentName, color);
 }
 
 export function getEnvironmentThemeStyle(theme: EnvironmentTheme): string {

--- a/main.go
+++ b/main.go
@@ -132,12 +132,23 @@ func main() {
 				log.Printf("Error fetching OCI repositories: %v", err)
 			}
 
+			var environments interface{}
+			if namespace == "all" || namespace == "*" || namespace == "" {
+				environments, err = k8sClient.GetEnvironmentsAllNamespaces(context.Background())
+			} else {
+				environments, err = k8sClient.GetEnvironments(context.Background(), namespace)
+			}
+			if err != nil {
+				log.Printf("Error fetching environments: %v", err)
+			}
+
 			c.JSON(http.StatusOK, gin.H{
 				"rollouts":          rollouts,
 				"imagePolicies":     imagePolicies,
 				"imageRepositories": imageRepositories,
 				"kustomizations":    kustomizations,
 				"ociRepositories":   ociRepositories,
+				"environments":      environments,
 			})
 		})
 

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -1225,6 +1225,15 @@ func (c *Client) GetEnvironments(ctx context.Context, namespace string) (*envv1a
 	return environments, nil
 }
 
+// GetEnvironmentsAllNamespaces fetches all Environments across all namespaces
+func (c *Client) GetEnvironmentsAllNamespaces(ctx context.Context) (*envv1alpha1.EnvironmentList, error) {
+	environments := &envv1alpha1.EnvironmentList{}
+	if err := c.client.List(ctx, environments); err != nil {
+		return nil, fmt.Errorf("failed to list environments across all namespaces: %w", err)
+	}
+	return environments, nil
+}
+
 // GetPodsBySelector lists pods matching the given label selector
 func (c *Client) GetPodsBySelector(ctx context.Context, namespace string, selector labels.Selector) (*corev1.PodList, error) {
 	pods := &corev1.PodList{}


### PR DESCRIPTION
## Summary

Reworks the rollouts list (`/`) into a denser, more useful control-panel view that groups rollouts by namespace / app / environment and surfaces the signals engineers actually care about (failed, baking, stuck-on-gates, behind-lead, pinned, pending upgrades). Visual language follows the existing app conventions (Flowbite Card / Badge / Popover, `environment-theme-badge`, status colors).

## What's in it

**Layout & filtering**
- Each group becomes a Flowbite card containing its rollouts as a divider-separated list (no per-row cards). Groups bubble worst-severity to the top.
- Three grouping modes — **Namespace · App · Environment** — persisted in `localStorage` (`rollouts:groupBy`).
- Filters live in a collapsible panel (no top-bar chrome by default). Search + group toggle stay anchored; active filters appear as small dismissible chips on their own row below the toolbar.
- Status filter includes a new **`stuck`** option.

**New per-rollout signals**
- **Pinned** — reads `spec.wantedVersion`, shown in orange with `PauseSolid` per `AlertPanel` convention.
- **`waiting` / `stuck`** — splits gate-waiting from genuinely stuck via a per-rollout heuristic: `mean + 1·stdev` of historical `timestamp − version.created` wait times (30-min floor; 7-day fallback). Help `Popover` (same shape as `HealthCheckBadge`) explains the math.
- **`behind <lead>`** — for each rollout, find the same-named sibling with the newest deploy. Count versions in lead's history not yet deployed here. Slow-threshold = `mean + 1·stdev` of historical promotion lags (per matching version). Same popover shape as stuck.
- **Aligned deploy timeline** per row — shared time axis within the group (clipped to one deploy before the group's oldest current version, so older noise is dropped). Lets you spot cross-deployment correlations.

**Backend**
- `/api/rollouts` now also returns Environments (`GetEnvironmentsAllNamespaces`). The frontend builds a `(namespace, rolloutName) → Environment` map and feeds it into `getRolloutEnvironmentTheme`, so env tags resolve on the list the same way they do on the detail page.

**Environment label semantics**
- `EnvironmentTheme` now exposes both `label` (canonical preset for the Navbar) and `environmentName` (raw `spec.environment` for the list/detail). No more auto-fill from preset label, so rollouts without an Environment (e.g. `*-manifests`) render with no env badge — matches the detail page.
- List uses the shared `<JoinedBadge label=\"Environment\" value={...} />` component (same one the detail title bar uses).

## Test plan

- [ ] Open the list — confirm grouping by Namespace works and the toggle is sticky across reloads.
- [ ] Switch to App grouping — confirm same-named rollouts collapse into one group; check the **behind <lead>** indicator on prod/staging rows.
- [ ] Switch to Environment grouping — confirm rollouts without an env show under `No environment`.
- [ ] Open the filter panel — toggle Status, Env, Namespace; verify per-section Clear and the dismissible active chips below the toolbar.
- [ ] Pinned indicator: pin a rollout (`spec.wantedVersion`) and confirm the orange Pinned chip appears.
- [ ] Stuck heuristic: leave a release candidate waiting long enough; verify the orange `stuck Xd` chip + popover (with threshold and lead).
- [ ] Behind-lead: with App grouping, confirm a slow downstream env shows `▼ N behind <env> · Xd` in orange when above its own historical threshold.
- [ ] Env badge: confirm `hello-world-app` (has Environment) renders `Environment | <env-name>`, while `hello-world-manifests` (no Environment) renders no env badge.
- [ ] Navbar on the detail page still shows the canonical preset label (`Staging`, `Production`).
- [ ] Mobile: meta line wraps cleanly when signals overflow; toolbar doesn't push the group toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)