### PR TITLE
oauth2-proxy extAuth for OIDC + vite dev auto-login

### DIFF
--- a/frontend/dev-auth.ts
+++ b/frontend/dev-auth.ts
@@ -1,0 +1,223 @@
+// Local-dev OIDC auto-login.
+//
+// On first /api or /oauth2 request, fetches an ID token from Dex via the
+// Resource Owner Password Credentials grant using the hardcoded local-dev
+// admin@example.com/password creds, caches it, and injects it as
+// Authorization: Bearer <token> on every subsequent proxied request.
+//
+// Pair with oauth2-proxy --skip-jwt-bearer-tokens=true so the cluster
+// accepts bearer tokens instead of the session cookie. The token survives
+// vite restarts since it's keyed off Dex's TTL (24h by default).
+//
+// On Dex restart all signing keys rotate, invalidating cached tokens.
+// The plugin runs an http reverse proxy itself (not vite's built-in proxy)
+// so it can detect oauth2-proxy's 302→/dex/auth response, drop the cached
+// token, and retry transparently.
+import http from 'node:http';
+import https from 'node:https';
+import { URL } from 'node:url';
+import type { Plugin } from 'vite';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+
+const DEFAULT_DEX_TOKEN_URL = 'https://192.168.1.102.nip.io:10443/dex/token';
+const DEFAULT_PATHS = ['/api'];
+const CLIENT_ID = 'rollout-dashboard';
+const CLIENT_SECRET = 'rollout-dashboard-secret';
+const USERNAME = 'admin@example.com';
+const PASSWORD = 'password';
+const SCOPE = 'openid email profile groups audience:server:client_id:kubernetes';
+
+interface TokenResponse {
+	id_token: string;
+	access_token: string;
+	expires_in: number;
+}
+
+function postForm(url: string, params: URLSearchParams): Promise<{ statusCode: number; body: string }> {
+	return new Promise((resolve, reject) => {
+		const u = new URL(url);
+		const data = params.toString();
+		const req = https.request(
+			{
+				hostname: u.hostname,
+				port: u.port || 443,
+				path: u.pathname + u.search,
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded',
+					'Content-Length': Buffer.byteLength(data)
+				},
+				rejectUnauthorized: false
+			},
+			(res) => {
+				const chunks: Buffer[] = [];
+				res.on('data', (c) => chunks.push(c));
+				res.on('end', () =>
+					resolve({ statusCode: res.statusCode ?? 0, body: Buffer.concat(chunks).toString() })
+				);
+			}
+		);
+		req.on('error', reject);
+		req.write(data);
+		req.end();
+	});
+}
+
+async function fetchTokenFromDex(dexUrl: string): Promise<TokenResponse> {
+	const params = new URLSearchParams({
+		grant_type: 'password',
+		username: USERNAME,
+		password: PASSWORD,
+		scope: SCOPE,
+		client_id: CLIENT_ID,
+		client_secret: CLIENT_SECRET
+	});
+	const { statusCode, body } = await postForm(dexUrl, params);
+	if (statusCode !== 200) {
+		throw new Error(`Dex token request failed: ${statusCode} ${body}`);
+	}
+	return JSON.parse(body) as TokenResponse;
+}
+
+function readBody(req: IncomingMessage): Promise<Buffer> {
+	return new Promise((resolve, reject) => {
+		const chunks: Buffer[] = [];
+		req.on('data', (c) => chunks.push(c));
+		req.on('end', () => resolve(Buffer.concat(chunks)));
+		req.on('error', reject);
+	});
+}
+
+function isDexRedirect(status: number | undefined, location: string | undefined): boolean {
+	return status === 302 && !!location && location.includes('/dex/auth');
+}
+
+interface ProxyOpts {
+	target: string;
+	getToken: () => Promise<string>;
+	invalidateToken: () => void;
+}
+
+async function proxyRequest(
+	req: IncomingMessage,
+	res: ServerResponse,
+	opts: ProxyOpts
+): Promise<void> {
+	const target = new URL(opts.target);
+	const isHttps = target.protocol === 'https:';
+	const lib = isHttps ? https : http;
+	const body =
+		req.method && req.method !== 'GET' && req.method !== 'HEAD' ? await readBody(req) : null;
+
+	for (let attempt = 0; attempt < 2; attempt++) {
+		const token = await opts.getToken();
+		const headers: http.OutgoingHttpHeaders = { ...req.headers };
+		headers.host = target.host;
+		headers.authorization = `Bearer ${token}`;
+		if (body) headers['content-length'] = body.length;
+
+		const upstream = await new Promise<IncomingMessage>((resolve, reject) => {
+			const r = lib.request(
+				{
+					hostname: target.hostname,
+					port: target.port || (isHttps ? 443 : 80),
+					path: req.url,
+					method: req.method,
+					headers,
+					rejectUnauthorized: false
+				},
+				resolve
+			);
+			r.on('error', reject);
+			if (body) r.write(body);
+			r.end();
+		});
+
+		if (attempt === 0 && isDexRedirect(upstream.statusCode, upstream.headers.location as string)) {
+			console.warn('[dev-auth] oauth2-proxy rejected token (likely Dex restart) — refreshing');
+			upstream.resume();
+			opts.invalidateToken();
+			continue;
+		}
+
+		res.statusCode = upstream.statusCode ?? 502;
+		for (const [k, v] of Object.entries(upstream.headers)) {
+			if (v !== undefined) res.setHeader(k, v as string | string[]);
+		}
+		upstream.pipe(res);
+		return;
+	}
+}
+
+export function devAuthPlugin(opts: { dexTokenUrl?: string; paths?: Record<string, string> } = {}): Plugin {
+	const dexUrl = opts.dexTokenUrl ?? process.env.DEX_TOKEN_URL ?? DEFAULT_DEX_TOKEN_URL;
+	// Map of path-prefix → upstream target. Defaults match the cluster ingress.
+	const routes =
+		opts.paths ??
+		({
+			'/api': 'https://kuberik.192.168.1.102.nip.io:8080',
+			'/oauth2': 'https://kuberik.192.168.1.102.nip.io:8080'
+		} as Record<string, string>);
+
+	let cache: { token: string; expiresAt: number } | null = null;
+	let inflight: Promise<string> | null = null;
+
+	async function getToken(): Promise<string> {
+		if (cache && cache.expiresAt > Date.now() + 60_000) return cache.token;
+		if (inflight) return inflight;
+		inflight = (async () => {
+			try {
+				const t = await fetchTokenFromDex(dexUrl);
+				cache = { token: t.id_token, expiresAt: Date.now() + t.expires_in * 1000 };
+				console.log(
+					`[dev-auth] obtained id_token from Dex (expires in ${t.expires_in}s) as ${USERNAME}`
+				);
+				return t.id_token;
+			} finally {
+				inflight = null;
+			}
+		})();
+		return inflight;
+	}
+
+	function invalidateToken() {
+		cache = null;
+	}
+
+	function matchRoute(url: string): string | null {
+		for (const [prefix, target] of Object.entries(routes)) {
+			if (url === prefix || url.startsWith(prefix + '/') || url.startsWith(prefix + '?')) {
+				return target;
+			}
+		}
+		return null;
+	}
+
+	return {
+		name: 'dev-auth',
+		configResolved(config) {
+			// Strip vite's built-in proxy for the routes we handle, so our middleware wins.
+			if (config.server.proxy) {
+				for (const prefix of Object.keys(routes)) {
+					delete (config.server.proxy as Record<string, unknown>)[prefix];
+				}
+			}
+		},
+		configureServer(server) {
+			server.middlewares.use(async (req, res, next) => {
+				if (!req.url) return next();
+				const target = matchRoute(req.url);
+				if (!target) return next();
+				try {
+					await proxyRequest(req, res, { target, getToken, invalidateToken });
+				} catch (e) {
+					console.error('[dev-auth] proxy error:', e);
+					if (!res.headersSent) {
+						res.statusCode = 502;
+						res.end('dev-auth proxy error');
+					}
+				}
+			});
+		}
+	};
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,8 +5,10 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 import mkcert from 'vite-plugin-mkcert';
 import { mockApiPlugin } from './dev-mock-api';
+import { devAuthPlugin } from './dev-auth';
 
 const useMockApi = !!process.env.MOCK_API;
+const skipDevAuth = !!process.env.SKIP_DEV_AUTH;
 
 export default defineConfig({
 	define: {
@@ -14,6 +16,7 @@ export default defineConfig({
 	},
 	plugins: [
 		...(useMockApi ? [mockApiPlugin()] : []),
+		...(!useMockApi && !skipDevAuth ? [devAuthPlugin()] : []),
 		mkcert(),
 		tailwindcss(),
 		sveltekit(),
@@ -28,6 +31,11 @@ export default defineConfig({
 		...(!useMockApi && {
 			proxy: {
 				'/api': {
+					target: 'https://kuberik.192.168.1.102.nip.io:8080',
+					changeOrigin: true,
+					secure: false,
+				},
+				'/oauth2': {
 					target: 'https://kuberik.192.168.1.102.nip.io:8080',
 					changeOrigin: true,
 					secure: false,

--- a/pkg/auth/middleware.go
+++ b/pkg/auth/middleware.go
@@ -8,58 +8,32 @@ import (
 
 const TokenContextKey = "oidc_token"
 
-// ExtractTokenMiddleware extracts OIDC token from request headers or cookies
-// Envoy Gateway typically sets the token in:
-// 1. Authorization header (Bearer token)
-// 2. Or cookies (id_token, access_token)
-// The middleware stores the token in the context for use by handlers
+// ExtractTokenMiddleware extracts OIDC token from request headers or cookies.
+// oauth2-proxy extAuth sets Authorization: Bearer <access_token> via headersToBackend.
+// Cookies are a fallback for direct access or Envoy native OIDC.
 func ExtractTokenMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var token string
 
-		// With forwardAccessToken: true in SecurityPolicy, Envoy Gateway forwards the access token
-		// in the standard Authorization header. This is the preferred method.
-		// Fallback to cookies if Authorization header is not present.
-		accessTokenCookie := "access_token"
-		idTokenCookie := "id_token"
-		IdTokenCookie := "IdToken"
-
-		// Fallback to IdToken cookie if Authorization header not found
-		// This is often used by some OIDC providers/proxies
-		if token == "" {
-			if cookie, err := c.Cookie(IdTokenCookie); err == nil && cookie != "" {
-				token = cookie
+		// Authorization header is set by oauth2-proxy via Envoy extAuth headersToBackend.
+		authHeader := c.GetHeader("Authorization")
+		if authHeader != "" {
+			parts := strings.SplitN(authHeader, " ", 2)
+			if len(parts) == 2 && strings.ToLower(parts[0]) == "bearer" {
+				token = parts[1]
 			}
 		}
 
-		// Fallback to id_token cookie if IdToken not found
-		// Kubernetes API server requires ID token (JWT) for OIDC authentication
+		// Fallback: cookies for Envoy native OIDC or direct access.
 		if token == "" {
-			if cookie, err := c.Cookie(idTokenCookie); err == nil && cookie != "" {
-				token = cookie
-			}
-		}
-
-		// Fallback to access token cookie if ID token not found
-		if token == "" {
-			if cookie, err := c.Cookie(accessTokenCookie); err == nil && cookie != "" {
-				token = cookie
-			}
-		}
-
-		// Try Authorization header last (e.g. when forwardAccessToken is enabled)
-		if token == "" {
-			authHeader := c.GetHeader("Authorization")
-			if authHeader != "" {
-				// Extract Bearer token
-				parts := strings.SplitN(authHeader, " ", 2)
-				if len(parts) == 2 && strings.ToLower(parts[0]) == "bearer" {
-					token = parts[1]
+			for _, name := range []string{"IdToken", "id_token", "access_token"} {
+				if cookie, err := c.Cookie(name); err == nil && cookie != "" {
+					token = cookie
+					break
 				}
 			}
 		}
 
-		// Store token in context if found
 		if token != "" {
 			c.Set(TokenContextKey, token)
 		}

--- a/pkg/auth/middleware_test.go
+++ b/pkg/auth/middleware_test.go
@@ -49,7 +49,9 @@ func TestExtractTokenMiddleware(t *testing.T) {
 		assert.Equal(t, "fallback-token", w.Body.String())
 	})
 
-	t.Run("Prioritize cookies over Authorization header", func(t *testing.T) {
+	t.Run("Prioritize Authorization header over cookies", func(t *testing.T) {
+		// oauth2-proxy extAuth populates Authorization via headersToBackend, so
+		// it must outrank any leftover cookie from a previous auth scheme.
 		r := gin.New()
 		r.Use(ExtractTokenMiddleware())
 		r.GET("/test", func(c *gin.Context) {
@@ -65,6 +67,6 @@ func TestExtractTokenMiddleware(t *testing.T) {
 		r.ServeHTTP(w, req)
 
 		assert.Equal(t, http.StatusOK, w.Code)
-		assert.Equal(t, "cookie-token", w.Body.String())
+		assert.Equal(t, "header-token", w.Body.String())
 	})
 }

--- a/scripts/setup-dev-environment.sh
+++ b/scripts/setup-dev-environment.sh
@@ -260,3 +260,9 @@ for env in ${APP_ENVS}; do
       -p '{"imagePullSecrets":[{"name":"github-registry-credentials"}]}'
   done
 done
+
+# Set up OIDC auth via oauth2-proxy by default.
+# HOSTNAME_PREFIX and HOST_PORT are inherited from the calling environment
+# (set by setup-multi-cluster-dev.sh or defaulting to kuberik/8080 for single-cluster).
+HOSTNAME_PREFIX="${HOSTNAME_PREFIX}" HOST_PORT="${HOST_PORT:-8080}" \
+  "${SCRIPT_DIR}/setup-oidc-auth.sh"

--- a/scripts/setup-oidc-auth.sh
+++ b/scripts/setup-oidc-auth.sh
@@ -1,9 +1,24 @@
 #!/bin/bash
+# Deploy oauth2-proxy in auth-only mode and configure Envoy Gateway extAuth.
+#
+# Architecture:
+#   Browser → Envoy Gateway (TLS) → SecurityPolicy (extAuth → oauth2-proxy /oauth2/auth)
+#                                      ↓ 200: inject Authorization header → dashboard
+#                                      ↓ 302: redirect to /oauth2/start (login flow)
+#   /oauth2/* → HTTPRoute → oauth2-proxy (no auth, handles OIDC dance with Dex)
+#
+# oauth2-proxy runs with --upstream=static://200: it never proxies traffic, only checks
+# session cookies and injects auth headers. Any new service needing auth just gets the
+# SecurityPolicy applied to its HTTPRoute.
+#
+# Env vars (all optional, defaults match single-cluster setup):
+#   HOSTNAME_PREFIX  — subdomain prefix for dashboard hostname (default: kuberik)
+#   HOST_PORT        — host port mapped to kind cluster NodePort (default: 8080)
 set -e
 
-SCRIPT_DIR=$(dirname "$0")
-PROJECT_ROOT=$(dirname "$SCRIPT_DIR")
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 OUTPUT_DIR="${SCRIPT_DIR}/dex-certs"
+REDIRECT_URIS_FILE="${OUTPUT_DIR}/redirect-uris.txt"
 
 # Get Dex hostname
 if [ ! -f "${OUTPUT_DIR}/dex-hostname.txt" ]; then
@@ -13,117 +28,216 @@ fi
 DEX_HOST=$(cat "${OUTPUT_DIR}/dex-hostname.txt")
 DEX_ISSUER_URL="https://${DEX_HOST}:10443/dex"
 
-# Get host IP for the dashboard URL
+# Compute dashboard hostname and OAuth2 redirect URI for this cluster
 HOST_IP=$(ip route get 8.8.8.8 | awk '{print $7; exit}' || hostname -I | awk '{print $1}')
-DASHBOARD_URL="https://${HOST_IP}.nip.io:8080"
+HOSTNAME_PREFIX="${HOSTNAME_PREFIX:-kuberik}"
+HOST_PORT="${HOST_PORT:-8080}"
+DASHBOARD_HOSTNAME="${HOSTNAME_PREFIX}.${HOST_IP}.nip.io"
+DASHBOARD_URL="https://${DASHBOARD_HOSTNAME}:${HOST_PORT}"
+# Redirect URI always uses port 443 (the user-facing URL via socat/haproxy/vite).
+# For the hub: port 443 → socat/haproxy → vite → vite proxies /oauth2/ → port 8080 → oauth2-proxy.
+# For the spoke: port 443 → haproxy → spoke kind envoy → oauth2-proxy.
+# Using a different port here would split the OAuth2 flow across ports, breaking CSRF
+# (the CSRF cookie is set at /oauth2/start but the callback would land on a different port).
+REDIRECT_URI="https://${DASHBOARD_HOSTNAME}/oauth2/callback"
 
-echo "Configuring OIDC authentication for rollout dashboard using Envoy Gateway SecurityPolicy..."
-echo "Dex issuer URL: ${DEX_ISSUER_URL}"
-echo "Dashboard URL: ${DASHBOARD_URL}"
+echo "Configuring OIDC auth via oauth2-proxy extAuth..."
+echo "  Dex issuer:    ${DEX_ISSUER_URL}"
+echo "  Dashboard URL: ${DASHBOARD_URL}"
+echo "  Redirect URI:  ${REDIRECT_URI}"
 
-# OAuth2 client credentials
-# Use rollout-dashboard client and request tokens with audience "kubernetes"
-# via cross-client trust (kubernetes client trusts rollout-dashboard)
-CLIENT_ID="rollout-dashboard"
+# --- Accumulate redirect URIs (for multi-cluster: each cluster adds its own) ---
+touch "${REDIRECT_URIS_FILE}"
+if ! grep -qF "${REDIRECT_URI}" "${REDIRECT_URIS_FILE}"; then
+    echo "${REDIRECT_URI}" >> "${REDIRECT_URIS_FILE}"
+fi
+sort -u "${REDIRECT_URIS_FILE}" -o "${REDIRECT_URIS_FILE}"
+
+# --- Regenerate Dex config with all accumulated redirect URIs ---
+DEX_CONFIG="${OUTPUT_DIR}/dex.yaml"
+{
+cat <<EOF
+issuer: ${DEX_ISSUER_URL}
+web:
+  https: 0.0.0.0:10443
+  tlsCert: /dex-server.crt
+  tlsKey: /dex-server.key
+storage:
+  type: sqlite3
+  config:
+    # Persisted on a docker volume so signing keys survive restarts.
+    # If keys rotated each restart, kube-apiserver would keep a stale
+    # JWKS cache and reject every token until its next refresh.
+    file: /var/dex/dex.db
+staticClients:
+  - id: kubernetes
+    redirectURIs:
+      - http://localhost:8000
+    name: kubernetes
+    secret: kubernetes-client-secret
+    trustedPeers:
+    - rollout-dashboard
+  - id: rollout-dashboard
+    redirectURIs:
+EOF
+while IFS= read -r uri; do
+    echo "      - ${uri}"
+done < "${REDIRECT_URIS_FILE}"
+cat <<'EOF'
+    name: Rollout Dashboard
+    secret: rollout-dashboard-secret
+enablePasswordDB: true
+oauth2:
+  passwordConnector: local
+staticPasswords:
+  - email: "admin@example.com"
+    hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
+    username: "admin"
+    userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
+EOF
+} > "${DEX_CONFIG}"
+
+# --- Restart Dex with updated config ---
+echo "Restarting Dex with updated redirect URIs..."
+if docker ps -a --format '{{.Names}}' | grep -q "^dex-server$"; then
+    docker stop dex-server 2>/dev/null || true
+    docker rm dex-server 2>/dev/null || true
+fi
+chmod 644 "${OUTPUT_DIR}/dex-server.crt" "${DEX_CONFIG}" 2>/dev/null || true
+chmod 644 "${OUTPUT_DIR}/dex-server.key" 2>/dev/null || true
+# Persistent volume for the dex sqlite db — keeps signing keys stable across
+# script reruns (see storage.config.file in the dex config above).
+docker volume inspect dex-storage >/dev/null 2>&1 || docker volume create dex-storage >/dev/null
+docker run -d --name dex-server -p 10443:10443 \
+  -v "${OUTPUT_DIR}/dex-server.crt:/dex-server.crt:ro" \
+  -v "${OUTPUT_DIR}/dex-server.key:/dex-server.key:ro" \
+  -v "${DEX_CONFIG}:/dex.yaml:ro" \
+  -v dex-storage:/var/dex \
+  "ghcr.io/dexidp/dex:v2.44.0" dex serve /dex.yaml
+echo "Waiting for Dex to be ready..."
+sleep 3
+
+# --- K8s resources: deploy oauth2-proxy and configure Envoy extAuth ---
+
+# Client secret and cookie secret
 CLIENT_SECRET="rollout-dashboard-secret"
+COOKIE_SECRET=$(openssl rand -base64 32 | tr -- '+/' '-_' | head -c 32)
 
-# Cookie names for Envoy Gateway OIDC
-ACCESS_TOKEN_COOKIE="access_token"
-ID_TOKEN_COOKIE="id_token"
-
-# Remove OAuth2 proxy if it exists
-kubectl delete deployment oauth2-proxy -n kuberik-system 2>/dev/null || true
-kubectl delete service oauth2-proxy -n kuberik-system 2>/dev/null || true
-
-# Create secret with OAuth2 client credentials
-kubectl create secret generic rollout-dashboard-oidc \
+kubectl create secret generic oauth2-proxy-secrets \
   --from-literal=client-secret="${CLIENT_SECRET}" \
+  --from-literal=cookie-secret="${COOKIE_SECRET}" \
   -n kuberik-system \
   --dry-run=client -o yaml | kubectl apply -f -
 
-# Create ConfigMap with Dex CA certificate for BackendTLSPolicy
+# Dex CA cert ConfigMap (needed by oauth2-proxy to trust Dex's self-signed cert)
 kubectl create configmap dex-ca-cert \
   --from-file=ca.crt="${OUTPUT_DIR}/dex-ca.crt" \
   -n kuberik-system \
   --dry-run=client -o yaml | kubectl apply -f -
 
-# Create Backend resource for Dex OIDC provider (for self-signed certificate support)
+# oauth2-proxy Deployment
 cat <<EOF | kubectl apply -f -
-apiVersion: gateway.envoyproxy.io/v1alpha1
-kind: Backend
+apiVersion: apps/v1
+kind: Deployment
 metadata:
-  name: dex-oidc-provider
+  name: oauth2-proxy
   namespace: kuberik-system
 spec:
-  endpoints:
-  - fqdn:
-      hostname: '${DEX_HOST}'
-      port: 10443
-EOF
-
-# Create BackendTLSPolicy separately (may need to delete old one first)
-kubectl delete backendlspolicy dex-ca-policy -n kuberik-system 2>/dev/null || true
-sleep 1
-cat <<EOF | kubectl apply -f -
-apiVersion: gateway.networking.k8s.io/v1alpha3
-kind: BackendTLSPolicy
+  replicas: 1
+  selector:
+    matchLabels:
+      app: oauth2-proxy
+  template:
+    metadata:
+      labels:
+        app: oauth2-proxy
+    spec:
+      containers:
+      - name: oauth2-proxy
+        image: quay.io/oauth2-proxy/oauth2-proxy:v7.7.1
+        args:
+        - --provider=oidc
+        - --oidc-issuer-url=${DEX_ISSUER_URL}
+        - --client-id=rollout-dashboard
+        - --email-domain=*
+        - --upstream=static://200
+        - --http-address=0.0.0.0:4180
+        - --redirect-url=${REDIRECT_URI}
+        - --scope=openid email profile groups audience:server:client_id:kubernetes
+        - --set-authorization-header=true
+        - --pass-access-token=true
+        - --set-xauthrequest=true
+        - --oidc-extra-audience=kubernetes
+        - --skip-provider-button=true
+        - --cookie-secure=true
+        - --cookie-samesite=lax
+        - --reverse-proxy=true
+        - --provider-ca-file=/etc/ssl/dex/ca.crt
+        # Accept JWT bearer tokens signed by Dex without requiring a session cookie.
+        # Lets vite dev server inject an Authorization header obtained via ROPC,
+        # so local dev doesn't need the interactive login flow.
+        - --skip-jwt-bearer-tokens=true
+        env:
+        - name: OAUTH2_PROXY_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: oauth2-proxy-secrets
+              key: client-secret
+        - name: OAUTH2_PROXY_COOKIE_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: oauth2-proxy-secrets
+              key: cookie-secret
+        ports:
+        - containerPort: 4180
+        volumeMounts:
+        - name: dex-ca
+          mountPath: /etc/ssl/dex
+          readOnly: true
+      volumes:
+      - name: dex-ca
+        configMap:
+          name: dex-ca-cert
+---
+apiVersion: v1
+kind: Service
 metadata:
-  name: dex-ca-policy
+  name: oauth2-proxy
   namespace: kuberik-system
 spec:
-  targetRefs:
-  - group: gateway.envoyproxy.io
-    kind: Backend
-    name: dex-oidc-provider
-  validation:
-    caCertificateRefs:
-    - name: dex-ca-cert
-      group: ""
-      kind: ConfigMap
-    hostname: ${DEX_HOST}
+  selector:
+    app: oauth2-proxy
+  ports:
+  - port: 4180
+    targetPort: 4180
 EOF
 
-# Wait for Backend to be ready
-echo "Waiting for Backend resource to be ready..."
-sleep 2
-
-# Create SecurityPolicy with OIDC configuration and cookie names
-# Request the audience:server:client_id:kubernetes scope to get tokens with audience "kubernetes"
-# See: https://dexidp.io/docs/configuration/custom-scopes-claims-clients/#cross-client-trust-and-authorized-party
+# HTTPRoute for /oauth2/* — handled by oauth2-proxy, NO SecurityPolicy applied.
+# This must be a separate HTTPRoute so the extAuth SecurityPolicy (on rollout-dashboard
+# HTTPRoute) doesn't also gate the OAuth2 flow itself.
 cat <<EOF | kubectl apply -f -
-apiVersion: gateway.envoyproxy.io/v1alpha1
-kind: SecurityPolicy
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
 metadata:
-  name: rollout-dashboard-oidc
+  name: oauth2-proxy
   namespace: kuberik-system
 spec:
-  targetRefs:
-    - group: gateway.networking.k8s.io
-      kind: HTTPRoute
-      name: rollout-dashboard
-  oidc:
-    provider:
-      issuer: ${DEX_ISSUER_URL}
-      authorizationEndpoint: ${DEX_ISSUER_URL}/auth
-      tokenEndpoint: ${DEX_ISSUER_URL}/token
-    clientID: ${CLIENT_ID}
-    clientSecret:
-      name: rollout-dashboard-oidc
-    redirectURL: ${DASHBOARD_URL}/oauth2/callback
-    logoutPath: /oauth2/sign_out
-    forwardAccessToken: true
-    cookieNames:
-      accessToken: ${ACCESS_TOKEN_COOKIE}
-      idToken: ${ID_TOKEN_COOKIE}
-    scopes:
-    - openid
-    - email
-    - profile
-    - groups
-    - audience:server:client_id:kubernetes
+  parentRefs:
+    - name: rollout-dashboard-gateway
+      namespace: kuberik-system
+  hostnames:
+    - ${DASHBOARD_HOSTNAME}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /oauth2
+      backendRefs:
+        - name: oauth2-proxy
+          port: 4180
 EOF
 
-# Update HTTPRoute to point back to dashboard (not OAuth2 proxy)
+# Update the dashboard HTTPRoute (all non-/oauth2 traffic goes to the dashboard).
 cat <<EOF | kubectl apply -f -
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -131,67 +245,67 @@ metadata:
   name: rollout-dashboard
   namespace: kuberik-system
   annotations:
-    # Disable buffering for SSE endpoints
     gateway.envoyproxy.io/response-buffering: "false"
 spec:
   parentRefs:
     - name: rollout-dashboard-gateway
       namespace: kuberik-system
   hostnames:
-    - ${HOST_IP}.nip.io
+    - ${DASHBOARD_HOSTNAME}
   rules:
     - matches:
         - path:
             type: PathPrefix
             value: /
       timeouts:
-        backendRequest: 0s  # No timeout for backend requests (SSE connections)
+        backendRequest: 0s
       backendRefs:
         - name: rollout-dashboard
           port: 80
 EOF
 
-# Update Dex configuration with dashboard URL
-echo "Updating Dex configuration with dashboard OAuth2 client..."
-DEX_CONFIG="${OUTPUT_DIR}/dex.yaml"
-DEX_CONFIG_TEMPLATE="${SCRIPT_DIR}/dex.yaml"
+# Remove old Envoy native OIDC SecurityPolicy if present from a previous setup.
+kubectl delete securitypolicy rollout-dashboard-oidc -n kuberik-system 2>/dev/null || true
 
-# Generate Dex config with hostname and dashboard URL substitution
-sed -e "s|https://dex-server:10443/dex|https://${DEX_HOST}:10443/dex|g" \
-    -e "s|DASHBOARD_URL_PLACEHOLDER|${HOST_IP}.nip.io|g" \
-    "${DEX_CONFIG_TEMPLATE}" > "${DEX_CONFIG}.tmp"
+# SecurityPolicy: extAuth using oauth2-proxy.
+# Envoy sends each request to oauth2-proxy /oauth2/auth (via the original request path).
+# oauth2-proxy checks the session cookie:
+#   authenticated  → 200 + sets Authorization/X-Auth-Request-* headers
+#   unauthenticated → 302 to /oauth2/start (handled by oauth2-proxy HTTPRoute, no loop)
+# headersToBackend copies the auth service response headers into the upstream request.
+cat <<EOF | kubectl apply -f -
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: oauth2-proxy-auth
+  namespace: kuberik-system
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: rollout-dashboard
+  extAuth:
+    http:
+      backendRefs:
+        - name: oauth2-proxy
+          port: 4180
+          namespace: kuberik-system
+      headersToBackend:
+        - Authorization
+        - X-Auth-Request-User
+        - X-Auth-Request-Email
+        - X-Auth-Request-Access-Token
+EOF
 
-# Verify the replacement worked and move to final location
-if grep -q "DASHBOARD_URL_PLACEHOLDER" "${DEX_CONFIG}.tmp"; then
-    echo "Error: Dashboard URL placeholder not replaced in Dex config"
-    exit 1
-fi
-mv "${DEX_CONFIG}.tmp" "${DEX_CONFIG}"
-
-# Restart Dex with new configuration
-echo "Restarting Dex with updated configuration..."
-"${SCRIPT_DIR}/setup-dex.sh"
-
-# setup-dex.sh regenerates the config, so we need to update it again with the dashboard URL
-echo "Updating Dex config with dashboard redirect URL..."
-sed -i "s|DASHBOARD_URL_PLACEHOLDER|${HOST_IP}.nip.io|g" "${DEX_CONFIG}"
-
-# Restart Dex again with the corrected config
-if docker ps --format '{{.Names}}' | grep -q "^dex-server$"; then
-    echo "Restarting Dex with corrected redirect URL..."
-    docker restart dex-server
-    sleep 2
-fi
+# Wait for oauth2-proxy to be ready
+echo "Waiting for oauth2-proxy to be ready..."
+kubectl rollout status deployment/oauth2-proxy -n kuberik-system --timeout=120s
 
 echo ""
-echo "✓ OIDC authentication configured for rollout dashboard using Envoy Gateway SecurityPolicy"
+echo "✓ OIDC auth configured via oauth2-proxy extAuth"
 echo ""
-echo "The dashboard is now protected by Envoy Gateway's native OIDC authentication."
-echo "Access the dashboard at: ${DASHBOARD_URL}"
+echo "  Dashboard: ${DASHBOARD_URL}"
+echo "  Auth flow: Envoy → extAuth(oauth2-proxy) → dashboard"
+echo "  Login:     ${DASHBOARD_URL}/oauth2/start"
 echo ""
-echo "You will be redirected to Dex for authentication."
-echo "Default credentials: admin@example.com / password"
-echo ""
-echo "Cookie names configured:"
-echo "  - Access Token: ${ACCESS_TOKEN_COOKIE}"
-echo "  - ID Token: ${ID_TOKEN_COOKIE}"
+echo "  Credentials: admin@example.com / password"


### PR DESCRIPTION
## Summary
- Replace Envoy native OIDC with a shared **oauth2-proxy** running in auth-only mode (`--upstream=static://200`) wired to Envoy Gateway's `SecurityPolicy` `extAuth`. Any new service inherits auth by targeting the same SecurityPolicy at its `HTTPRoute` — oauth2-proxy never sees the backend.
- Hardcoded **vite dev auto-login**: a vite plugin fetches an `id_token` from Dex via ROPC (using local-dev `admin@example.com` / `password`) and runs its own reverse proxy for `/api` and `/oauth2` so dev doesn't need the interactive login flow. On a `302→/dex/auth` from oauth2-proxy (e.g. after a Dex restart) the cached token is dropped and the request retries once, so the dev loop self-heals.
- **Persistent Dex storage**: sqlite db moved to a docker volume so signing keys survive restarts. Otherwise kube-apiserver's JWKS cache goes stale on every setup rerun and rejects every token.

## Key pieces
- `scripts/setup-oidc-auth.sh` — deploys oauth2-proxy + Dex CA configmap, splits `/oauth2/*` onto its own HTTPRoute (no extAuth → no auth loop on the OAuth2 callback), and pins `redirect_uri` to port 443 so the CSRF cookie set at `/oauth2/start` matches the callback through the vite/haproxy chain.
- `pkg/auth/middleware.go` — Authorization header first (oauth2-proxy populates it via `headersToBackend`), cookies as fallback.
- `frontend/dev-auth.ts` — vite plugin (token cache + ROPC + self-managed proxy + 302 retry).
- `oauth2-proxy --skip-jwt-bearer-tokens=true` — required so the cluster accepts the bearer issued by the vite plugin without a session cookie.

## Test plan
- [x] Hub (port 8080) `/api/health` without bearer → 302 to `/oauth2/start`
- [x] Hub `/api/health` with valid bearer → 200
- [x] Spoke (port 8081) bearer flow same
- [x] Vite (`https://localhost:5173`) `/api/rollouts` → 200, fanout returns spoke cluster, no `clusterErrors`
- [x] `docker restart dex-server` then re-request → still 200 (signing keys persist on the `dex-storage` volume)
- [ ] Interactive browser login via `/oauth2/start` (cookie path) still works for non-dev callers

🤖 Generated with [Claude Code](https://claude.com/claude-code)