### PR TITLE
fix: route change-version + schedules through spoke proxy

### DIFF
--- a/frontend/src/lib/components/DeployModal.svelte
+++ b/frontend/src/lib/components/DeployModal.svelte
@@ -19,6 +19,8 @@
 		isPinVersionMode?: boolean;
 		// Optional initial explanation (e.g., for rollback)
 		initialExplanation?: string;
+		// Multi-cluster: remote dashboard URL when this rollout lives on a spoke.
+		dashboard?: string;
 		// Callbacks
 		onSuccess?: (message: string) => void;
 		onError?: (message: string) => void;
@@ -31,6 +33,7 @@
 		selectedVersionDisplay = null,
 		isPinVersionMode = false,
 		initialExplanation = '',
+		dashboard,
 		onSuccess = () => {},
 		onError = () => {}
 	}: Props = $props();
@@ -101,8 +104,9 @@
 		if (!rollout || !selectedVersionTag) return;
 
 		try {
+			const dashboardParam = dashboard ? `?dashboard=${encodeURIComponent(dashboard)}` : '';
 			const response = await fetch(
-				`/api/rollouts/${rollout.metadata?.namespace}/${rollout.metadata?.name}/change-version`,
+				`/api/rollouts/${rollout.metadata?.namespace}/${rollout.metadata?.name}/change-version${dashboardParam}`,
 				{
 					method: 'POST',
 					headers: { 'Content-Type': 'application/json' },

--- a/frontend/src/lib/components/FailurePanel.svelte
+++ b/frontend/src/lib/components/FailurePanel.svelte
@@ -18,6 +18,7 @@
 		canUpdate: boolean;
 		canModify: boolean;
 		isDashboardManagingWantedVersion: boolean;
+		dashboard?: string;
 		onRetry: (kruiseRolloutName?: string, testAction?: string) => Promise<void>;
 		onSuccess?: (message: string) => void;
 		onError?: (message: string) => void;
@@ -32,6 +33,7 @@
 		canUpdate,
 		canModify,
 		isDashboardManagingWantedVersion,
+		dashboard,
 		onRetry,
 		onSuccess = () => {},
 		onError = () => {}
@@ -195,6 +197,7 @@
 	selectedVersionDisplay={rollbackVersionTag}
 	isPinVersionMode={true}
 	initialExplanation={rollbackExplanation}
+	{dashboard}
 	{onSuccess}
 	{onError}
 />

--- a/frontend/src/lib/components/ScheduleStatus.svelte
+++ b/frontend/src/lib/components/ScheduleStatus.svelte
@@ -47,7 +47,9 @@
 		};
 	};
 
-	let { rollout }: { rollout: Rollout } = $props();
+	// `dashboard` is the spoke URL when the rollout lives on a remote cluster;
+	// it's appended as ?dashboard=<url> so the hub proxies the call to that spoke.
+	let { rollout, dashboard }: { rollout: Rollout; dashboard?: string } = $props();
 
 	let allSchedules = $state<Array<RolloutSchedule | ClusterRolloutSchedule>>([]);
 	let loading = $state(true);
@@ -231,8 +233,9 @@
 
 	async function fetchSchedules() {
 		try {
+			const dashboardParam = dashboard ? `?dashboard=${encodeURIComponent(dashboard)}` : '';
 			const response = await fetch(
-				`/api/rollouts/${rollout.metadata.namespace}/${rollout.metadata.name}/schedules`
+				`/api/rollouts/${rollout.metadata.namespace}/${rollout.metadata.name}/schedules${dashboardParam}`
 			);
 			if (!response.ok) throw new Error('Failed to fetch schedules');
 

--- a/frontend/src/routes/rollouts/[namespace]/[name]/+page.svelte
+++ b/frontend/src/routes/rollouts/[namespace]/[name]/+page.svelte
@@ -1360,7 +1360,7 @@
 				</div>
 
 				<!-- ══ SCHEDULE STATUS (blocking / closing-soon) ══ -->
-				<ScheduleStatus {rollout} />
+				<ScheduleStatus {rollout} {dashboard} />
 
 				<!-- ══ FAILURE PANEL ══ -->
 				{#if isFailed}
@@ -1373,6 +1373,7 @@
 						{canUpdate}
 						{canModify}
 						{isDashboardManagingWantedVersion}
+						{dashboard}
 						onRetry={retryDeployment}
 						onSuccess={(m) => { toastType = 'success'; toastMessage = m; showToast = true; setTimeout(() => (showToast = false), 3000); }}
 						onError={(m) => { toastType = 'error'; toastMessage = m; showToast = true; setTimeout(() => (showToast = false), 3000); }}
@@ -2237,6 +2238,7 @@
 	selectedVersionDisplay={selectedVersionDisplay()}
 	{isPinVersionMode}
 	initialExplanation={deployExplanation}
+	{dashboard}
 	onSuccess={(m) => {
 		toastType = 'success';
 		toastMessage = m;

--- a/frontend/src/routes/rollouts/[namespace]/[name]/history/+page.svelte
+++ b/frontend/src/routes/rollouts/[namespace]/[name]/history/+page.svelte
@@ -632,6 +632,7 @@
 			{selectedVersionDisplay}
 			isPinVersionMode={true}
 			initialExplanation={deployExplanation}
+			{dashboard}
 		/>
 	{/if}
 </div>


### PR DESCRIPTION
Stacked on #15.

## Summary
`DeployModal.handleDeploy` and `ScheduleStatus.fetchSchedules` were hitting `/api/rollouts/.../change-version` and `/.../schedules` without `?dashboard=`. With multi-cluster fan-out, the hub then looked the rollout up locally and 500'd whenever it lived on a spoke. Threads the `dashboard` prop through from the rollout detail/history pages and `FailurePanel` so the hub's spoke-proxy middleware can forward these calls to the right cluster.

## Test plan
- [x] `POST /api/rollouts/<ns>/<name>/change-version?dashboard=<spoke>` via vite → 200, mutation applied on spoke
- [x] `GET /api/rollouts/<ns>/<name>/schedules?dashboard=<spoke>` via vite → 200
- [ ] Browser: open a spoke rollout from the list, click "Deploy version" → no 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)