### PR TITLE
fix: thread dashboard param through remaining spoke-bound fetches

### DIFF
--- a/frontend/src/lib/components/DeployModal.svelte
+++ b/frontend/src/lib/components/DeployModal.svelte
@@ -19,6 +19,8 @@
 		isPinVersionMode?: boolean;
 		// Optional initial explanation (e.g., for rollback)
 		initialExplanation?: string;
+		// Multi-cluster: remote dashboard URL when this rollout lives on a spoke.
+		dashboard?: string;
 		// Callbacks
 		onSuccess?: (message: string) => void;
 		onError?: (message: string) => void;
@@ -31,6 +33,7 @@
 		selectedVersionDisplay = null,
 		isPinVersionMode = false,
 		initialExplanation = '',
+		dashboard,
 		onSuccess = () => {},
 		onError = () => {}
 	}: Props = $props();
@@ -101,8 +104,9 @@
 		if (!rollout || !selectedVersionTag) return;
 
 		try {
+			const dashboardParam = dashboard ? `?dashboard=${encodeURIComponent(dashboard)}` : '';
 			const response = await fetch(
-				`/api/rollouts/${rollout.metadata?.namespace}/${rollout.metadata?.name}/change-version`,
+				`/api/rollouts/${rollout.metadata?.namespace}/${rollout.metadata?.name}/change-version${dashboardParam}`,
 				{
 					method: 'POST',
 					headers: { 'Content-Type': 'application/json' },

--- a/frontend/src/lib/components/FailurePanel.svelte
+++ b/frontend/src/lib/components/FailurePanel.svelte
@@ -18,6 +18,7 @@
 		canUpdate: boolean;
 		canModify: boolean;
 		isDashboardManagingWantedVersion: boolean;
+		dashboard?: string;
 		onRetry: (kruiseRolloutName?: string, testAction?: string) => Promise<void>;
 		onSuccess?: (message: string) => void;
 		onError?: (message: string) => void;
@@ -32,6 +33,7 @@
 		canUpdate,
 		canModify,
 		isDashboardManagingWantedVersion,
+		dashboard,
 		onRetry,
 		onSuccess = () => {},
 		onError = () => {}
@@ -195,6 +197,7 @@
 	selectedVersionDisplay={rollbackVersionTag}
 	isPinVersionMode={true}
 	initialExplanation={rollbackExplanation}
+	{dashboard}
 	{onSuccess}
 	{onError}
 />

--- a/frontend/src/lib/components/ResourcesCard.svelte
+++ b/frontend/src/lib/components/ResourcesCard.svelte
@@ -15,12 +15,18 @@
 	let {
 		kustomizations,
 		ociRepositories,
-		filteredManagedResources
+		filteredManagedResources,
+		dashboard
 	}: {
 		kustomizations: Kustomization[];
 		ociRepositories: OCIRepository[];
 		filteredManagedResources: Record<string, ManagedResourceStatus[]>;
+		// Spoke URL when this rollout lives on a remote cluster — appended as
+		// ?dashboard=<url> so the hub proxies deployment-children lookups too.
+		dashboard?: string;
 	} = $props();
+
+	const dashboardParam = $derived(dashboard ? `?dashboard=${encodeURIComponent(dashboard)}` : '');
 
 	// All managed resources (for status summary + "other" section)
 	const allManagedResources = $derived(
@@ -64,7 +70,7 @@
 				expandedDeployments = new Set([...expandedDeployments, key]);
 				if (!deploymentChildren[key]) {
 					deploymentChildren = { ...deploymentChildren, [key]: { replicaSets: [], loading: true } };
-					fetch(`/api/namespaces/${resource.namespace}/deployments/${resource.name}/children`)
+					fetch(`/api/namespaces/${resource.namespace}/deployments/${resource.name}/children${dashboardParam}`)
 						.then((r) => r.json())
 						.then((data) => {
 							deploymentChildren = { ...deploymentChildren, [key]: { replicaSets: data.replicaSets || [], loading: false } };
@@ -119,7 +125,7 @@
 
 		try {
 			const res = await fetch(
-				`/api/namespaces/${resource.namespace}/deployments/${resource.name}/children`
+				`/api/namespaces/${resource.namespace}/deployments/${resource.name}/children${dashboardParam}`
 			);
 			if (!res.ok) throw new Error('Failed to fetch children');
 			const data = await res.json();
@@ -146,7 +152,7 @@
 				const ns = key.substring(0, slashIdx);
 				const depName = key.substring(slashIdx + 1);
 				try {
-					const res = await fetch(`/api/namespaces/${ns}/deployments/${depName}/children`);
+					const res = await fetch(`/api/namespaces/${ns}/deployments/${depName}/children${dashboardParam}`);
 					if (!res.ok) continue;
 					const data = await res.json();
 					deploymentChildren = {

--- a/frontend/src/lib/components/ScheduleStatus.svelte
+++ b/frontend/src/lib/components/ScheduleStatus.svelte
@@ -47,7 +47,9 @@
 		};
 	};
 
-	let { rollout }: { rollout: Rollout } = $props();
+	// `dashboard` is the spoke URL when the rollout lives on a remote cluster;
+	// it's appended as ?dashboard=<url> so the hub proxies the call to that spoke.
+	let { rollout, dashboard }: { rollout: Rollout; dashboard?: string } = $props();
 
 	let allSchedules = $state<Array<RolloutSchedule | ClusterRolloutSchedule>>([]);
 	let loading = $state(true);
@@ -231,8 +233,9 @@
 
 	async function fetchSchedules() {
 		try {
+			const dashboardParam = dashboard ? `?dashboard=${encodeURIComponent(dashboard)}` : '';
 			const response = await fetch(
-				`/api/rollouts/${rollout.metadata.namespace}/${rollout.metadata.name}/schedules`
+				`/api/rollouts/${rollout.metadata.namespace}/${rollout.metadata.name}/schedules${dashboardParam}`
 			);
 			if (!response.ok) throw new Error('Failed to fetch schedules');
 

--- a/frontend/src/lib/components/SourceViewer.svelte
+++ b/frontend/src/lib/components/SourceViewer.svelte
@@ -11,6 +11,9 @@
 	export let namespace: string;
 	export let name: string;
 	export let version: string;
+	// Spoke URL when this rollout lives on a remote cluster — appended as
+	// ?dashboard=<url> so the hub proxies the manifest fetch to that spoke.
+	export let dashboard: string | undefined = undefined;
 
 	let files: Record<string, string> = {};
 	let loading = false;
@@ -30,7 +33,10 @@
 		loading = true;
 		error = null;
 		try {
-			const response = await fetch(`/api/rollouts/${namespace}/${name}/manifest/${version}`);
+			const dashboardParam = dashboard ? `?dashboard=${encodeURIComponent(dashboard)}` : '';
+			const response = await fetch(
+				`/api/rollouts/${namespace}/${name}/manifest/${version}${dashboardParam}`
+			);
 			if (!response.ok) {
 				throw new Error(`Failed to fetch files: ${response.statusText}`);
 			}

--- a/frontend/src/routes/rollouts/[namespace]/[name]/+page.svelte
+++ b/frontend/src/routes/rollouts/[namespace]/[name]/+page.svelte
@@ -1360,7 +1360,7 @@
 				</div>
 
 				<!-- ══ SCHEDULE STATUS (blocking / closing-soon) ══ -->
-				<ScheduleStatus {rollout} />
+				<ScheduleStatus {rollout} {dashboard} />
 
 				<!-- ══ FAILURE PANEL ══ -->
 				{#if isFailed}
@@ -1373,6 +1373,7 @@
 						{canUpdate}
 						{canModify}
 						{isDashboardManagingWantedVersion}
+						{dashboard}
 						onRetry={retryDeployment}
 						onSuccess={(m) => { toastType = 'success'; toastMessage = m; showToast = true; setTimeout(() => (showToast = false), 3000); }}
 						onError={(m) => { toastType = 'error'; toastMessage = m; showToast = true; setTimeout(() => (showToast = false), 3000); }}
@@ -2238,6 +2239,7 @@
 	selectedVersionDisplay={selectedVersionDisplay()}
 	{isPinVersionMode}
 	initialExplanation={deployExplanation}
+	{dashboard}
 	onSuccess={(m) => {
 		toastType = 'success';
 		toastMessage = m;

--- a/frontend/src/routes/rollouts/[namespace]/[name]/+page.svelte
+++ b/frontend/src/routes/rollouts/[namespace]/[name]/+page.svelte
@@ -1499,6 +1499,7 @@
 											namespace={rollout.metadata?.namespace || ''}
 											name={rollout.metadata?.name || ''}
 											version={latestEntry.version.tag}
+											{dashboard}
 										/>
 									{/if}
 									{#if rollout?.status?.source}
@@ -1895,7 +1896,7 @@
 							</div>
 						{/if}
 						<HealthChecksCard healthChecks={visibleHealthChecks} />
-						<ResourcesCard {kustomizations} {ociRepositories} {filteredManagedResources} />
+						<ResourcesCard {kustomizations} {ociRepositories} {filteredManagedResources} {dashboard} />
 						<EventsCard {events} />
 					</div>
 				</div>

--- a/frontend/src/routes/rollouts/[namespace]/[name]/history/+page.svelte
+++ b/frontend/src/routes/rollouts/[namespace]/[name]/history/+page.svelte
@@ -87,8 +87,11 @@
 					const ksName = ks.metadata!.name as string;
 					const ksNamespace = ks.metadata?.namespace || namespace;
 					try {
+						const dashboardParam = dashboard
+							? `?dashboard=${encodeURIComponent(dashboard)}`
+							: '';
 						const res = await fetch(
-							`/api/kustomizations/${ksNamespace}/${ksName}/managed-resources`
+							`/api/kustomizations/${ksNamespace}/${ksName}/managed-resources${dashboardParam}`
 						);
 						if (res.ok) {
 							const data = await res.json();
@@ -542,6 +545,7 @@
 												namespace={rollout.metadata?.namespace || ''}
 												name={rollout.metadata?.name || ''}
 												version={entry.version.tag}
+												{dashboard}
 											/>
 										{/if}
 										{#if i < (rollout?.status?.history?.length ?? 0) - 1 && rollout?.status?.artifactType === 'application/vnd.cncf.flux.config.v1+json'}

--- a/frontend/src/routes/rollouts/[namespace]/[name]/history/+page.svelte
+++ b/frontend/src/routes/rollouts/[namespace]/[name]/history/+page.svelte
@@ -636,6 +636,7 @@
 			{selectedVersionDisplay}
 			isPinVersionMode={true}
 			initialExplanation={deployExplanation}
+			{dashboard}
 		/>
 	{/if}
 </div>


### PR DESCRIPTION
## Summary
Sweep of the spots that hit \`/api/*\` directly (not via \`apiUrl()\` / the api/rollouts helpers) and so silently 404/500'd on spoke rollouts. Each one was verified against the hub before fixing:

| Endpoint | Without \`?dashboard=\` | Visible symptom |
|---|---|---|
| \`/api/namespaces/<ns>/deployments/<x>/children\` | 404 *"Deployment not found"* | ResourcesCard auto-expand on an unhealthy spoke Deployment + manual expand + 5s refresh all error. |
| \`/api/rollouts/<ns>/<n>/manifest/<v>\` | 500 *"rollout not found"* | SourceViewer's "View Source" button. Only renders for \`artifactType: flux.config.v1+json\` so silent for OCI image rollouts — fixed for consistency. |
| \`/api/kustomizations/<ns>/<n>/managed-resources\` (history page copy) | 500 *"kustomization not found"* | Datadog test info on the history page never resolves for spoke rollouts. |

The other untracked-by-helpers calls (logs SSE, diff page, +page.svelte's managed-resources, all the mutation handlers in +page.svelte) already pass the dashboard param.

## Test plan
- [x] \`/api/namespaces/.../deployments/.../children?dashboard=<spoke>\` → 200 with replica sets
- [x] \`/api/kustomizations/.../managed-resources?dashboard=<spoke>\` → 200 with inventory
- [ ] Browser: open a spoke rollout with an unhealthy Deployment, expand it → children show up

🤖 Generated with [Claude Code](https://claude.com/claude-code)