### PR TITLE
fix: preserve selectedVersion through recovery warning modal flow

### DIFF
--- a/frontend/src/routes/rollouts/[namespace]/[name]/+page.svelte
+++ b/frontend/src/routes/rollouts/[namespace]/[name]/+page.svelte
@@ -392,7 +392,7 @@
 
 	// Reset state when modals close
 	$effect(() => {
-		if (!showPinModal && !showDeployModal) {
+		if (!showPinModal && !showDeployModal && !showRecoveryWarningModal) {
 			selectedVersion = null;
 			searchQuery = '';
 			showAllTags = false;


### PR DESCRIPTION
## Summary

- Deploy Version modal sometimes appeared with an empty version badge when the rollout was in recovery mode
- Root cause: the reset effect cleared `selectedVersion` when `showPinModal` closed and `showDeployModal` was still `false` — exactly the state when `requestDeployModal()` routes through `RecoveryModeWarningModal` before opening `DeployModal`
- Fix: add `\!showRecoveryWarningModal` to the reset guard so `selectedVersion` survives until the user acts on the warning

## Test plan

- [ ] Trigger "Change Version" on a rollout with a failed/unhealthy bake status (recovery mode active)
- [ ] Select a version and click Continue — RecoveryModeWarningModal should appear
- [ ] Click Continue on the warning — DeployModal should show the correct version in the badge
- [ ] Verify Cancel on warning resets state correctly (no lingering version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)