### PR TITLE
fix(rollouts): truncate long versions in list view

### DIFF
--- a/frontend/src/lib/RolloutGrid.svelte
+++ b/frontend/src/lib/RolloutGrid.svelte
@@ -743,11 +743,17 @@
 											<DeployVolumeSparkline rollouts={[c.rollout]} hours={24} buckets={12} />
 										</div>
 
-										<!-- Version + age block (right side) -->
+										<!-- Version + age block (right side). `min-w-0` on the
+										     version span itself is required for `truncate` to
+										     ellipsize inside flex parents — without it, long
+										     versions (full git SHAs, pinned tags with hex
+										     suffixes) overflow the column. `shortenVersion`
+										     trims obvious SHA-like values for compactness; the
+										     full string is preserved in the `title` attribute. -->
 										<div class="col-start-2 row-start-2 flex min-w-0 flex-col sm:col-start-auto sm:row-start-auto sm:items-end">
-											<div class="flex min-w-0 items-baseline gap-1.5">
+											<div class="flex min-w-0 max-w-full items-baseline gap-1.5">
 												{#if c.pinnedVersion}<PinBadge version={c.pinnedVersion} size="xs" />{/if}
-												<span class="truncate font-mono text-sm font-medium text-gray-900 dark:text-white" title={c.version ?? ''}>{c.version ?? '—'}</span>
+												<span class="min-w-0 truncate font-mono text-sm font-medium text-gray-900 dark:text-white" title={c.version ?? ''}>{c.version ? shortenVersion(c.version) : '—'}</span>
 											</div>
 											{#if c.timestamp}
 												<span class="font-mono text-[10px] {c.isRunning ? 'text-yellow-700 dark:text-yellow-400' : 'text-gray-500 dark:text-gray-400'}" title={formatTimeAgo(c.timestamp, $now)}>

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isFieldManaged, isFieldManagedByManager, isFieldManagedByOtherManager, parseLinkAnnotations, extractDatadogInfoFromContainers, buildDatadogTestRunsUrl, buildDatadogLogsUrl, buildDatadogTraceSearchUrl } from './utils';
+import { isFieldManaged, isFieldManagedByManager, isFieldManagedByOtherManager, parseLinkAnnotations, extractDatadogInfoFromContainers, buildDatadogTestRunsUrl, buildDatadogLogsUrl, buildDatadogTraceSearchUrl, shortenVersion } from './utils';
 import {
     ENVIRONMENT_THEME_ANNOTATION,
     ENVIRONMENT_THEME_COLOR_ANNOTATION,
@@ -498,5 +498,40 @@ describe('buildDatadogTraceSearchUrl', () => {
         expect(url).toContain(encodeURIComponent('env:staging'));
         expect(url).toContain(encodeURIComponent('@rollout.test:true'));
         expect(url).not.toContain(encodeURIComponent('version:'));
+    });
+});
+
+describe('shortenVersion', () => {
+    it('returns empty string for nullish input', () => {
+        expect(shortenVersion(null)).toBe('');
+        expect(shortenVersion(undefined)).toBe('');
+        expect(shortenVersion('')).toBe('');
+    });
+
+    it('shortens a full 40-char git SHA to 7 chars', () => {
+        expect(shortenVersion('cf9292d57497bfccae1be39609c2c0e50b4de1ce')).toBe('cf9292d');
+        expect(shortenVersion('7BD43E1956F3B822B948BD0EEA9DBD08B4673DDB')).toBe('7BD43E1');
+    });
+
+    it('keeps tag prefix and shortens long hex suffix after a dash', () => {
+        expect(shortenVersion('main-1776963445-50ef792e2bd4b2c21c1e2b13f064e05c9e84034d'))
+            .toBe('main-1776963445-50ef792');
+        expect(shortenVersion('release-abcdef0123456789')).toBe('release-abcdef0');
+    });
+
+    it('leaves already-short SHAs alone', () => {
+        expect(shortenVersion('a7e115f')).toBe('a7e115f');
+        expect(shortenVersion('ebe9fb6')).toBe('ebe9fb6');
+    });
+
+    it('leaves non-hex versions alone', () => {
+        expect(shortenVersion('1.2.3')).toBe('1.2.3');
+        expect(shortenVersion('v1.2.3-rc1')).toBe('v1.2.3-rc1');
+        expect(shortenVersion('0.3.0-1779831037')).toBe('0.3.0-1779831037');
+        expect(shortenVersion('main-1.2.3')).toBe('main-1.2.3');
+    });
+
+    it('does not shorten short hex tails (<12 chars)', () => {
+        expect(shortenVersion('release-abc1234')).toBe('release-abc1234');
     });
 });

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -393,6 +393,23 @@ export function getDisplayVersion(versionInfo: {
 }
 
 /**
+ * Shorten long version strings for compact display in cells/badges.
+ * - Full git SHA (40 hex chars) → first 7 chars (e.g. cf9292d)
+ * - Tag with a long hex suffix after a dash (≥12 hex chars, e.g.
+ *   main-1776963445-50ef792…) → keep prefix and shorten the hex tail to 7
+ * Returns the input unchanged if it's already short or doesn't match.
+ * The full version should still be exposed via a `title` attribute for
+ * users who need to copy or read the full string.
+ */
+export function shortenVersion(version: string | null | undefined): string {
+    if (!version) return version ?? '';
+    if (/^[0-9a-f]{40}$/i.test(version)) return version.slice(0, 7);
+    const m = version.match(/^(.+-)([0-9a-f]{12,})$/i);
+    if (m) return m[1] + m[2].slice(0, 7);
+    return version;
+}
+
+/**
  * Extracts URL from gateway or ingress API resources
  * @param resource The managed resource with object field
  * @param groupVersionKind The groupVersionKind string (e.g., "networking.k8s.io/v1/Ingress")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Long versions overflowed the version column on the rollouts list and visually broke row alignment:

- Full 40-char git SHAs (e.g. `cf9292d57497bfccae1be39609c2c0e50b4de1ce`) extended past the column.
- Pinned tags with long hex suffixes (e.g. `main-1776963445-50ef792e2bd4b2c21c1e2b13f064e05c9e84034d`) blew out group rows.

## Fix

Two small changes in `frontend/src/lib/RolloutGrid.svelte` plus a shared helper in `frontend/src/lib/utils.ts`:

- **CSS**: add `min-w-0` to the version `<span>`. Inside a flex parent, `truncate` needs the truncating element itself to have `min-width: 0` — otherwise its default `min-width: auto` keeps it at intrinsic content width and ellipsis never engages.
- **Display compaction**: new `shortenVersion(version)` helper that:
  - shortens a pure 40-hex SHA to the first 7 characters
  - keeps the prefix and shortens any long hex tail (≥12 chars) after a dash, e.g. `main-1776963445-50ef792`
  - leaves semver, short SHAs, and short hex tails untouched
- The full version is still available via the row's `title` attribute, so users can hover to copy or read the complete string.

## Tests

Added unit tests in `frontend/src/lib/utils.test.ts` covering:

- nullish input
- full 40-char SHA shortening (preserves case)
- tag + long hex suffix shortening
- already-short SHAs left alone
- non-hex / semver versions left alone
- hex tails shorter than 12 chars left alone

`npm run build` and `npm run test:unit` succeed (the 3 pre-existing failures in `environment themes` are unrelated to this change — confirmed by stashing and re-running on `main`).

## Out of scope

This PR intentionally does not touch the multi-cluster cluster/env filter rendering or the fan-out merge logic — those are being investigated separately.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18c218e3-41cf-4c34-a5f6-fe58cc1b76ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18c218e3-41cf-4c34-a5f6-fe58cc1b76ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

